### PR TITLE
Node modules still being excluded from bundle

### DIFF
--- a/TerraformCLI/package-lock.json
+++ b/TerraformCLI/package-lock.json
@@ -1890,7 +1890,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2305,7 +2306,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2361,6 +2363,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2404,12 +2407,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -6527,12 +6532,6 @@
           }
         }
       }
-    },
-    "webpack-node-externals": {
-      "version": "1.7.2",
-      "resolved": "http://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-1.7.2.tgz",
-      "integrity": "sha512-ajerHZ+BJKeCLviLUUmnyd5B4RavLF76uv3cs6KNuO8W+HuQaEs0y0L7o40NQxdPy5w0pcv8Ew7yPUAQG0UdCg==",
-      "dev": true
     },
     "webpack-sources": {
       "version": "1.3.0",

--- a/TerraformCLI/package.json
+++ b/TerraformCLI/package.json
@@ -7,7 +7,7 @@
     "build": "./node_modules/.bin/webpack && tsc --project ./src/tests",
     "pack": "./node_modules/.bin/copyfiles task.json icon.png \".bin/*.js\" -e \".bin/tests/*\" .dist",
     "delete": "./node_modules/.bin/tfx build tasks delete --task-id 721c3f90-d938-11e8-9d92-09d7594721b5",
-    "upload": "./node_modules/.bin/tfx build tasks upload --task-path .",
+    "upload": "./node_modules/.bin/tfx build tasks upload --task-path .dist",
     "start": "node --require dotenv/config .dist/.bin/index.js",
     "test": "nyc -r cobertura -r html ./node_modules/.bin/mocha \".bin/tests/**/*_spec.js\" --reporter mocha-junit-reporter --reporter-options mochaFile=./.test-output/terraform-cli.xml",
     "test:local": "./node_modules/.bin/mocha \".bin/tests/**/*_spec.js\""
@@ -42,8 +42,7 @@
     "ts-node": "^7.0.1",
     "typescript": "^3.1.3",
     "webpack": "^4.26.0",
-    "webpack-cli": "^3.1.2",
-    "webpack-node-externals": "^1.7.2"
+    "webpack-cli": "^3.1.2"
   },
   "dependencies": {
     "azure-pipelines-task-lib": "^2.7.1",

--- a/TerraformCLI/webpack.config.js
+++ b/TerraformCLI/webpack.config.js
@@ -1,10 +1,8 @@
 const path = require('path');
-const nodeExternals = require('webpack-node-externals');
 
 module.exports = {
   entry: './src/index.ts',
   target: 'node',
-  externals: [nodeExternals()],
   mode: 'none',
   module: {
     rules: [

--- a/TerraformInstaller/package-lock.json
+++ b/TerraformInstaller/package-lock.json
@@ -2192,14 +2192,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2214,20 +2212,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2344,8 +2339,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2357,7 +2351,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2372,7 +2365,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2380,14 +2372,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2406,7 +2396,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2487,8 +2476,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2500,7 +2488,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2622,7 +2609,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7163,12 +7149,6 @@
           }
         }
       }
-    },
-    "webpack-node-externals": {
-      "version": "1.7.2",
-      "resolved": "http://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-1.7.2.tgz",
-      "integrity": "sha512-ajerHZ+BJKeCLviLUUmnyd5B4RavLF76uv3cs6KNuO8W+HuQaEs0y0L7o40NQxdPy5w0pcv8Ew7yPUAQG0UdCg==",
-      "dev": true
     },
     "webpack-sources": {
       "version": "1.3.0",

--- a/TerraformInstaller/package.json
+++ b/TerraformInstaller/package.json
@@ -7,7 +7,7 @@
     "build": "./node_modules/.bin/webpack",
     "pack": "./node_modules/.bin/copyfiles task.json icon.png \".bin/*.js\" -e \".bin/tests/*\" .dist",
     "delete": "./node_modules/.bin/tfx build tasks delete --task-id 11645770-d18e-11e8-8f5b-1b8b62612b3b",
-    "upload": "./node_modules/.bin/tfx build tasks upload --task-path .",
+    "upload": "./node_modules/.bin/tfx build tasks upload --task-path .dist",
     "start": "node --require dotenv/config .dist/.bin/index.js",
     "test": "nyc -r cobertura -r html ./node_modules/.bin/mocha \".bin/tests/**/*_spec.js\" --reporter mocha-junit-reporter --reporter-options mochaFile=./.test-output/terraform-installer.xml",
     "test:local": "npm run build && ./node_modules/.bin/mocha \".bin/tests/**/*_spec.js\""
@@ -44,7 +44,6 @@
     "ts-node": "^7.0.1",
     "typescript": "^3.1.6",
     "webpack": "^4.26.1",
-    "webpack-cli": "^3.1.2",
-    "webpack-node-externals": "^1.7.2"
+    "webpack-cli": "^3.1.2"
   }
 }

--- a/TerraformInstaller/webpack.config.js
+++ b/TerraformInstaller/webpack.config.js
@@ -1,10 +1,8 @@
 const path = require('path');
-const nodeExternals = require('webpack-node-externals');
 
 module.exports = {
   entry: './src/index.ts',
   target: 'node',
-  externals: [nodeExternals()],
   mode: 'none',
   module: {
     rules: [


### PR DESCRIPTION
#8 

Despite using webpack to package the task, it appears that when node modules are not uploaded with the task the dependencies are still unresolvable. This was due to a webpack extension webpack-node-externals. This was thought to only exclude known globally installed packages such as `fs` but, it is excluding everything. This change removes that extension.

Also the task uploaded to the test az devops org during the release pipeline for testing was uploading the contents of the entire task src folder which includes the node_modules. This was causing the task to appear to pass automated testing. This has been fixed to only upload the contents of the .dist folder which is what is included in the vsix. This does not include the node_modules folder