### PR TITLE
Removed hard coded task version in CLI

### DIFF
--- a/TerraformCLI/task.json
+++ b/TerraformCLI/task.json
@@ -12,9 +12,9 @@
     ],
     "demands": [],
     "version": {
-        "Major": "0",
-        "Minor": "2",
-        "Patch": "4"
+        "Major": "#{GitVersion.Major}#",
+        "Minor": "#{GitVersion.Minor}#",
+        "Patch": "#{GitVersion.Patch}#"
     },
     "minimumAgentVersion": "1.95.0",
     "instanceNameFormat": "terraform $(command)",


### PR DESCRIPTION
Fix for #63. 

Replaced hard coded version with version calculated from GitVer. This was reported to be preventing users from being able to access new features due to version-based caching.