### PR TITLE
Fix issue where -detailed-exitcode causes task to fail

### DIFF
--- a/TerraformCLI/src/terraform-plan.ts
+++ b/TerraformCLI/src/terraform-plan.ts
@@ -55,18 +55,18 @@ export class TerraformPlanHandler implements IHandleCommandString{
 
         let execOptions: IExecOptions = <IExecOptions>{
             cwd: command.workingDirectory,
-            // if using detailed exit code, disable automated interpretation of exit codes by the toolrunner so exit code 2 doesnt return error
-            ignoreReturnCode: command.options !== undefined && command.options.indexOf('-detailed-exitcode') > -1
+            // if using detailed exit code, disable automated interpretation of exit codes by the toolrunner so exit code 2 doesn't return error
+            ignoreReturnCode: command.options !== undefined && command.options !== null && command.options.indexOf('-detailed-exitcode') > -1
         };
 
-        let exitcode = await terraform.exec(execOptions);
+        let exitCode = await terraform.exec(execOptions);
 
         // ensure exit code 1 still throws error so task result is set to Failed. 
-        if(execOptions.ignoreReturnCode && exitcode === 1){
+        if(execOptions.ignoreReturnCode && exitCode === 1){
             throw "terraform plan failed with exit code 1";
         }
 
-        return exitcode;
+        return exitCode;
     }
 
     private async setupVars(command: TerraformPlan, terraform: ToolRunner){

--- a/TerraformCLI/src/tests/scenarios-terraform.ts
+++ b/TerraformCLI/src/tests/scenarios-terraform.ts
@@ -14,7 +14,7 @@ declare module "./scenarios"{
         inputAzureRmEnsureBackend(this: TaskScenario<TerraformInputs>, resourceGroupLocation?: string, storageAccountSku?: string): TaskScenario<TerraformInputs>;
         inputApplicationInsightsInstrumentationKey(this: TaskScenario<TerraformInputs>, instrumentationKey?: string): TaskScenario<TerraformInputs>;
         answerTerraformExists(this: TaskScenario<TerraformInputs>, terraformExists?: boolean): TaskScenario<TerraformInputs>;
-        answerTerraformCommandIsSuccessful(this: TaskScenario<TerraformInputs>, args?: string): TaskScenario<TerraformInputs>;
+        answerTerraformCommandIsSuccessful(this: TaskScenario<TerraformInputs>, args?: string, exitCode?: number): TaskScenario<TerraformInputs>;
         answerTerraformCommandWithVarsFileAsWorkingDirFails(this: TaskScenario<TerraformInputs>): TaskScenario<TerraformInputs>;
         answerAzExists(this: TaskScenario<TerraformInputs>, azExists?: boolean): TaskScenario<TerraformInputs>;
         answerAzCommandIsSuccessfulWithResultRaw<TCommand extends ICommand<TResult>, TResult>(this: TaskScenario<TerraformInputs>, command: TCommand, result: string): TaskScenario<TerraformInputs>;
@@ -134,9 +134,11 @@ TaskScenario.prototype.answerTerraformCommandWithVarsFileAsWorkingDirFails = fun
 
 export class TerraformCommandIsSuccessful extends TaskAnswerDecorator<TerraformInputs>{
     private readonly args: string | undefined;
-    constructor(builder: TaskAnswerBuilder<TerraformInputs>, args?: string) {
+    private readonly exitCode: number | undefined;
+    constructor(builder: TaskAnswerBuilder<TerraformInputs>, args?: string, exitCode?: number) {
         super(builder);
         this.args = args;
+        this.exitCode = exitCode;
     }
     build(inputs: TerraformInputs): TaskLibAnswers {
         let a = this.builder.build(inputs);
@@ -153,14 +155,14 @@ export class TerraformCommandIsSuccessful extends TaskAnswerDecorator<TerraformI
         } 
 
         a.exec[command] = <TaskLibAnswerExecResult>{
-            code : 0,
+            code : this.exitCode || 0,
             stdout : `${inputs.command} successful`
         }
         return a;
     }
 }
-TaskScenario.prototype.answerTerraformCommandIsSuccessful = function(this: TaskScenario<TerraformInputs>, args?: string): TaskScenario<TerraformInputs>{
-    this.answerFactory((builder) => new TerraformCommandIsSuccessful(builder, args));
+TaskScenario.prototype.answerTerraformCommandIsSuccessful = function(this: TaskScenario<TerraformInputs>, args?: string, exitCode?: number): TaskScenario<TerraformInputs>{
+    this.answerFactory((builder) => new TerraformCommandIsSuccessful(builder, args, exitCode));
     return this;
 }
 

--- a/TerraformCLI/src/tests/terraform-plan/plan-azurerm-with-detailed-exitcode-with-changes.env.ts
+++ b/TerraformCLI/src/tests/terraform-plan/plan-azurerm-with-detailed-exitcode-with-changes.env.ts
@@ -1,0 +1,29 @@
+let environmentServiceName = "dev";
+let subscriptionId: string = "sub1";
+let tenantId: string = "ten1";
+let servicePrincipalId: string = "servicePrincipal1";
+let servicePrincipalKey: string = "servicePrincipalKey123";
+
+let expectedEnv: { [key: string]: string } = {
+    'ARM_SUBSCRIPTION_ID': subscriptionId,
+    'ARM_TENANT_ID': tenantId,
+    'ARM_CLIENT_ID': servicePrincipalId,
+    'ARM_CLIENT_SECRET': servicePrincipalKey,
+}
+
+const terraformCommand: string = "plan";
+const commandOptions:string = "-input=true -lock=false -no-color -detailed-exitcode"
+const expectedCommand: string = `${terraformCommand} ${commandOptions}`
+
+export let env: any = {
+    taskScenarioPath:           require.resolve('./plan-azurerm-with-detailed-exitcode-with-changes'),
+    terraformCommand:           terraformCommand,
+    commandOptions:             commandOptions,
+    expectedCommand:            expectedCommand,
+    environmentServiceName:     environmentServiceName,
+    subscriptionId:             subscriptionId,
+    tenantId:                   tenantId,
+    servicePrincipalId:         servicePrincipalId,
+    servicePrincipalKey:        servicePrincipalKey,
+    expectedEnv:                expectedEnv
+}

--- a/TerraformCLI/src/tests/terraform-plan/plan-azurerm-with-detailed-exitcode-with-changes.ts
+++ b/TerraformCLI/src/tests/terraform-plan/plan-azurerm-with-detailed-exitcode-with-changes.ts
@@ -1,0 +1,14 @@
+import { TaskScenario } from './../scenarios';
+import { TerraformInputs } from '../scenarios-terraform';
+import '../scenarios-terraform';
+import { env } from './plan-azurerm-with-detailed-exitcode-with-changes.env';
+
+new TaskScenario<TerraformInputs>()
+    .inputAzureRmServiceEndpoint(env.environmentServiceName, env.subscriptionId, env.tenantId, env.servicePrincipalId, env.servicePrincipalKey)
+    .inputTerraformCommand(env.terraformCommand, env.commandOptions)
+    .input({ environmentServiceName: env.environmentServiceName })    
+    .inputApplicationInsightsInstrumentationKey()
+    .answerTerraformExists()    
+    .answerTerraformCommandIsSuccessful(env.commandOptions, 2)
+    .answerTerraformCommandWithVarsFileAsWorkingDirFails()
+    .run()

--- a/TerraformCLI/src/tests/terraform-plan/plan-azurerm-with-detailed-exitcode-without-changes.env.ts
+++ b/TerraformCLI/src/tests/terraform-plan/plan-azurerm-with-detailed-exitcode-without-changes.env.ts
@@ -1,0 +1,29 @@
+let environmentServiceName = "dev";
+let subscriptionId: string = "sub1";
+let tenantId: string = "ten1";
+let servicePrincipalId: string = "servicePrincipal1";
+let servicePrincipalKey: string = "servicePrincipalKey123";
+
+let expectedEnv: { [key: string]: string } = {
+    'ARM_SUBSCRIPTION_ID': subscriptionId,
+    'ARM_TENANT_ID': tenantId,
+    'ARM_CLIENT_ID': servicePrincipalId,
+    'ARM_CLIENT_SECRET': servicePrincipalKey,
+}
+
+const terraformCommand: string = "plan";
+const commandOptions:string = "-input=true -lock=false -no-color -detailed-exitcode"
+const expectedCommand: string = `${terraformCommand} ${commandOptions}`
+
+export let env: any = {
+    taskScenarioPath:           require.resolve('./plan-azurerm-with-detailed-exitcode-without-changes'),
+    terraformCommand:           terraformCommand,
+    commandOptions:             commandOptions,
+    expectedCommand:            expectedCommand,
+    environmentServiceName:     environmentServiceName,
+    subscriptionId:             subscriptionId,
+    tenantId:                   tenantId,
+    servicePrincipalId:         servicePrincipalId,
+    servicePrincipalKey:        servicePrincipalKey,
+    expectedEnv:                expectedEnv
+}

--- a/TerraformCLI/src/tests/terraform-plan/plan-azurerm-with-detailed-exitcode-without-changes.ts
+++ b/TerraformCLI/src/tests/terraform-plan/plan-azurerm-with-detailed-exitcode-without-changes.ts
@@ -1,0 +1,14 @@
+import { TaskScenario } from './../scenarios';
+import { TerraformInputs } from '../scenarios-terraform';
+import '../scenarios-terraform';
+import { env } from './plan-azurerm-with-detailed-exitcode-without-changes.env';
+
+new TaskScenario<TerraformInputs>()
+    .inputAzureRmServiceEndpoint(env.environmentServiceName, env.subscriptionId, env.tenantId, env.servicePrincipalId, env.servicePrincipalKey)
+    .inputTerraformCommand(env.terraformCommand, env.commandOptions)
+    .input({ environmentServiceName: env.environmentServiceName })    
+    .inputApplicationInsightsInstrumentationKey()
+    .answerTerraformExists()    
+    .answerTerraformCommandIsSuccessful(env.commandOptions, 0)
+    .answerTerraformCommandWithVarsFileAsWorkingDirFails()
+    .run()

--- a/TerraformCLI/src/tests/terraform-plan/plan_spec.ts
+++ b/TerraformCLI/src/tests/terraform-plan/plan_spec.ts
@@ -20,6 +20,22 @@ describe('terraform plan', function(){
             .assertExecutedTerraformVersion()
             .run();
     });
+    it('azurerm with detailed exit code and changes present', function(){        
+        let env = require('./plan-azurerm-with-detailed-exitcode-with-changes.env').env
+        new TestScenario(env.taskScenarioPath)
+            .assertExecutionSucceeded()
+            .assertExecutedTerraformCommand(env.expectedCommand)
+            .assertExecutedTerraformVersion()
+            .run();
+    });
+    it('azurerm with detailed exit code and no changes present', function(){        
+        let env = require('./plan-azurerm-with-detailed-exitcode-without-changes.env').env
+        new TestScenario(env.taskScenarioPath)
+            .assertExecutionSucceeded()
+            .assertExecutedTerraformCommand(env.expectedCommand)
+            .assertExecutedTerraformVersion()
+            .run();
+    });
     it('azurerm with secure var file', function(){
         let env = require('./plan-azurerm-with-secure-var-file.env').env;
         new TestScenario(env.taskScenarioPath)


### PR DESCRIPTION
This is to fix the issue reported with #16. This should allow the task to succeed when using plan with `-detailed-exitcode` option.The task will examine provided options. If the `-detailed-exitcode` option is provided, it will indicate to the ToolRunner class in the `azure-pipelines-task-lib` module to disable automatic interpretation of the returned exit code (i.e. non-zero exit code = failure). When the execution completes, the task will do the interpretation itself and determine exit codes 0 and 2 as success. Anything else is failure.

