### PR TITLE
Record which options were used to execute command without values

### DIFF
--- a/TerraformCLI/src/logger.ts
+++ b/TerraformCLI/src/logger.ts
@@ -14,10 +14,26 @@ export default class Logger implements ILogger {
 
     async command<TCommand extends TerraformCommand>(command: TCommand, handler: (command: TCommand) => Promise<number>, properties: any) : Promise<number>{
         let start: [number, number] = process.hrtime();
+        
+        let loggedOptions: any = {};
+        if(command.options){
+            let commandOptions = command.options.split(' ');            
+            commandOptions.forEach(commandOption => {
+                if(commandOption.startsWith('-')){       
+                    let loggedOption = "command-option" + commandOption;
+                    if(loggedOption.includes('=')){
+                        loggedOption = loggedOption.substr(0, (loggedOption.indexOf('=')));            
+                    }
+                    loggedOptions[loggedOption] = (loggedOptions[loggedOption] || 0) + 1;
+                }    
+            });
+        }
+
         let request: RequestTelemetry = <RequestTelemetry>{
             name: command.name,
-            properties: properties,
-        }
+            properties: { ...loggedOptions, ...properties }
+        };
+
         try{
             let rvalue: number = await handler(command);
             request.resultCode = 200;

--- a/TerraformCLI/src/terraform-apply.ts
+++ b/TerraformCLI/src/terraform-apply.ts
@@ -57,8 +57,8 @@ export class TerraformApplyHandler implements IHandleCommandString{
         );
 
         let loggedProps = {
-            "secureVarsFileDefined": apply.secureVarsFile !== undefined,
-            "commandOptionsDefined": apply.options !== undefined
+            "secureVarsFileDefined": apply.secureVarsFile !== undefined && apply.secureVarsFile !== '' && apply.secureVarsFile !== null,
+            "commandOptionsDefined": apply.options !== undefined && apply.options !== '' && apply.options !== null
         }
         
         return this.log.command(apply, (command: TerraformApply) => this.onExecute(command), loggedProps);

--- a/TerraformCLI/src/terraform-destroy.ts
+++ b/TerraformCLI/src/terraform-destroy.ts
@@ -46,8 +46,8 @@ export class TerraformDestroyHandler implements IHandleCommandString{
         );
 
         let loggedProps = {
-            "secureVarsFileDefined": destroy.secureVarsFile !== undefined,
-            "commandOptionsDefined": destroy.options !== undefined
+            "secureVarsFileDefined": destroy.secureVarsFile !== undefined && destroy.secureVarsFile !== '' && destroy.secureVarsFile !== null,
+            "commandOptionsDefined": destroy.options !== undefined && destroy.options !== '' && destroy.options !== null
         }
         
         return this.log.command(destroy, (command: TerraformDestroy) => this.onExecute(command), loggedProps);

--- a/TerraformCLI/src/terraform-init.ts
+++ b/TerraformCLI/src/terraform-init.ts
@@ -67,8 +67,8 @@ export class TerraformInitHandler implements IHandleCommandString{
         );
 
         let loggedProps = {
-            "backendType": init.backendType,
-            "commandOptionsDefined": init.options !== undefined
+            "backendType": init.backendType || BackendTypes.local,
+            "commandOptionsDefined": init.options !== undefined && init.options !== '' && init.options !== null
         };
 
         return this.log.command(init, (command: TerraformInit) => this.onExecute(command), loggedProps);

--- a/TerraformCLI/src/terraform-plan.ts
+++ b/TerraformCLI/src/terraform-plan.ts
@@ -46,8 +46,8 @@ export class TerraformPlanHandler implements IHandleCommandString{
         );
 
         let loggedProps = {
-            "secureVarsFileDefined": plan.secureVarsFile !== undefined,
-            "commandOptionsDefined": plan.options !== undefined
+            "secureVarsFileDefined": plan.secureVarsFile !== undefined && plan.secureVarsFile !== '' && plan.secureVarsFile !== null,
+            "commandOptionsDefined": plan.options !== undefined && plan.options !== '' && plan.options !== null
         }
         
         return this.log.command(plan, (command: TerraformPlan) => this.onExecute(command), loggedProps);
@@ -65,7 +65,7 @@ export class TerraformPlanHandler implements IHandleCommandString{
         };
 
         let exitCode = await terraform.exec(execOptions);
-
+        let foo = terraform.execSync()
         this.setPlanHasChangesVariable(command.options, exitCode);
 
         // ensure exit code 1 still throws error so task result is set to Failed. 

--- a/TerraformCLI/src/terraform-validate.ts
+++ b/TerraformCLI/src/terraform-validate.ts
@@ -42,8 +42,8 @@ export class TerraformValidateHandler implements IHandleCommandString{
         );
 
         let loggedProps = {
-            "secureVarsFileDefined": validate.secureVarsFile !== undefined,
-            "commandOptionsDefined": validate.options !== undefined
+            "secureVarsFileDefined": validate.secureVarsFile !== undefined && validate.secureVarsFile !== '' && validate.secureVarsFile !== null,
+            "commandOptionsDefined": validate.options !== undefined && validate.options !== '' && validate.options !== null
         }
         
         


### PR DESCRIPTION
Addresses the issue #73 and is implemented as suggested in the original description. This will not record any values provided with the options so that the telemetry does not include secrets. 