### PR TITLE
Translate stderr output to typed errors and exception telemetry

### DIFF
--- a/TerraformCLI/src/index.ts
+++ b/TerraformCLI/src/index.ts
@@ -1,7 +1,7 @@
 import tasks = require("azure-pipelines-task-lib/task");
 import { Container, interfaces } from 'inversify';
 import "reflect-metadata";
-import { TerraformInterfaces, TerraformProvider, ITerraformProvider, ITaskAgent, ILogger } from "./terraform";
+import { TerraformInterfaces, ITaskAgent, ILogger } from "./terraform";
 import { TerraformInitHandler } from "./terraform-init";
 import { TerraformVersionHandler } from "./terraform-version";
 import { TerraformValidateHandler } from "./terraform-validate";
@@ -44,7 +44,6 @@ var container = new Container();
 
 // bind infrastructure components
 container.bind<Container>("container").toConstantValue(container);
-container.bind<ITerraformProvider>(TerraformInterfaces.ITerraformProvider).toDynamicValue((context: interfaces.Context) => new TerraformProvider(tasks));
 container.bind<IMediator>(MediatorInterfaces.IMediator).to(Mediator);
 container.bind<ITaskAgent>(TerraformInterfaces.ITaskAgent).to(TaskAgent);
 container.bind<AzRunner>(AzRunner).toDynamicValue((context: interfaces.Context) => new AzRunner(tasks));

--- a/TerraformCLI/src/terraform-aggregate-error.ts
+++ b/TerraformCLI/src/terraform-aggregate-error.ts
@@ -1,0 +1,27 @@
+import { TerraformError } from "./terraform-error";
+export class TerraformAggregateError extends Error {
+    public readonly errors: TerraformError[];
+    constructor(command: string, stderr: string, exitCode: number) {
+        let lines: string[] = stderr
+            .replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '')
+            .split('\n\n')
+            .map(line => line.replace('\nError:', 'Error:'))
+            .map(line => line.replace('\n', ' '))
+            .filter(line => line && line !== "");
+        let message: string = lines
+            .filter(line => line.startsWith('Error:'))
+            .map(line => line.replace('Error:', ''))
+            .join(" | ");
+        super(message);
+        this.name = `Terraform command '${command}' failed with exit code '${exitCode}.`;
+        this.errors = [];
+        lines.forEach((line, i) => {
+            if (line.startsWith('Error:')) {
+                let name: string = line.replace('Error: ', '');
+                let message: string = lines[(i + 1)];
+                this.errors.push(new TerraformError(name, message));
+            }
+        });
+        console.log('Error lines: ', this.errors);
+    }
+}

--- a/TerraformCLI/src/terraform-aggregate-error.ts
+++ b/TerraformCLI/src/terraform-aggregate-error.ts
@@ -1,9 +1,12 @@
 import { TerraformError } from "./terraform-error";
+
 export class TerraformAggregateError extends Error {
     public readonly errors: TerraformError[];
+    public readonly stderr: string;
     constructor(command: string, stderr: string, exitCode: number) {
-        let lines: string[] = stderr
-            .replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '')
+        let stderrEscaped: string = stderr
+        .replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '');
+        let lines: string[] = stderrEscaped
             .split('\n\n')
             .map(line => line.replace('\nError:', 'Error:'))
             .map(line => line.replace('\n', ' '))
@@ -13,15 +16,15 @@ export class TerraformAggregateError extends Error {
             .map(line => line.replace('Error:', ''))
             .join(" | ");
         super(message);
+        this.stderr = stderrEscaped;
         this.name = `Terraform command '${command}' failed with exit code '${exitCode}.`;
         this.errors = [];
         lines.forEach((line, i) => {
             if (line.startsWith('Error:')) {
                 let name: string = line.replace('Error: ', '');
                 let message: string = lines[(i + 1)];
-                this.errors.push(new TerraformError(name, message));
+                this.errors.push(new TerraformError(name, message, this.stack));
             }
-        });
-        console.log('Error lines: ', this.errors);
+        });      
     }
 }

--- a/TerraformCLI/src/terraform-apply.ts
+++ b/TerraformCLI/src/terraform-apply.ts
@@ -1,10 +1,10 @@
 import tasks = require("azure-pipelines-task-lib/task");
-import { IExecOptions, ToolRunner } from "azure-pipelines-task-lib/toolrunner";
-import { TerraformCommand, TerraformInterfaces, ITerraformProvider, ITaskAgent, ILogger } from "./terraform";
+import { TerraformCommand, TerraformInterfaces, ITaskAgent, ILogger } from "./terraform";
 import { injectable, inject } from "inversify";
 import { IHandleCommandString } from "./command-handler";
+import { TerraformRunner } from "./terraform-runner";
 
-export class TerraformApply extends TerraformCommand{
+export class TerraformApply extends TerraformCommand {
     readonly secureVarsFile: string | undefined;
     readonly environmentServiceName: string;
 
@@ -22,42 +22,28 @@ export class TerraformApply extends TerraformCommand{
 
 @injectable()
 export class TerraformApplyHandler implements IHandleCommandString{
-    private readonly terraformProvider: ITerraformProvider;
     private readonly taskAgent: ITaskAgent;
     private readonly log: ILogger;
 
     constructor(
-        @inject(TerraformInterfaces.ITerraformProvider) terraformProvider: ITerraformProvider,
         @inject(TerraformInterfaces.ITaskAgent) taskAgent: ITaskAgent,
         @inject(TerraformInterfaces.ILogger) log: ILogger
-    ) {
-        this.terraformProvider = terraformProvider;           
+    ) {    
         this.taskAgent = taskAgent;     
         this.log = log;
     }
 
     public async execute(command: string): Promise<number> {
-        let autoApprove: string = '-auto-approve';
-        let commandOptions: string = tasks.getInput("commandOptions") || autoApprove;
-        if(commandOptions.includes(autoApprove) === false){
-            commandOptions = `${autoApprove} ${commandOptions}`;
-        }
-        let secureVarsFile: string = tasks.getInput("secureVarsFile");
-        if(secureVarsFile){
-            let secureVarsFilePath: string = await this.getSecureVarsFilePath(secureVarsFile);
-            commandOptions = `-var-file=${secureVarsFilePath} ${commandOptions}`;
-        }
-
         let apply = new TerraformApply(
             command,
             tasks.getInput("workingDirectory"),
             tasks.getInput("environmentServiceName", true),
-            secureVarsFile,
-            commandOptions
+            tasks.getInput("secureVarsFile"),
+            tasks.getInput("commandOptions")
         );
 
         let loggedProps = {
-            "secureVarsFileDefined": apply.secureVarsFile !== undefined,
+            //"secureVarsFileDefined": apply.secureVarsFile !== undefined,
             "commandOptionsDefined": apply.options !== undefined
         }
         
@@ -65,29 +51,10 @@ export class TerraformApplyHandler implements IHandleCommandString{
     }
 
     private async onExecute(command: TerraformApply): Promise<number> {
-        let terraform: ToolRunner = this.terraformProvider.create(command);
-        this.setupAzureRmProvider(command, terraform);
-        return terraform.exec(<IExecOptions>{
-            cwd: command.workingDirectory
-        });
-    }
-
-    private getSecureVarsFilePath(secureVarsFile: string): Promise<string>{
-        return this.taskAgent.downloadSecureFile(secureVarsFile);
-    }
-
-    private setupAzureRmProvider(command: TerraformApply, terraform: ToolRunner){
-        if(command.environmentServiceName){
-            let scheme = tasks.getEndpointAuthorizationScheme(command.environmentServiceName, true);
-            if(scheme != "ServicePrincipal"){
-                throw "Terraform only supports service principal authorization for azure";
-            }
-
-            process.env['ARM_SUBSCRIPTION_ID']  = tasks.getEndpointDataParameter(command.environmentServiceName, "subscriptionid", false);
-            process.env['ARM_TENANT_ID']        = tasks.getEndpointAuthorizationParameter(command.environmentServiceName, "tenantid", false);
-            process.env['ARM_CLIENT_ID']        = tasks.getEndpointAuthorizationParameter(command.environmentServiceName, "serviceprincipalid", false);
-            process.env['ARM_CLIENT_SECRET']    = tasks.getEndpointAuthorizationParameter(command.environmentServiceName, "serviceprincipalkey", false);
-        }
-        
+        return await new TerraformRunner(command)
+            .withSecureVarsFile(this.taskAgent, command.secureVarsFile)
+            .withAutoApprove()
+            .withAzureRmProvider(command.environmentServiceName)
+            .exec();
     }
 }

--- a/TerraformCLI/src/terraform-destroy.ts
+++ b/TerraformCLI/src/terraform-destroy.ts
@@ -1,8 +1,8 @@
 import tasks = require("azure-pipelines-task-lib/task");
-import { IExecOptions, ToolRunner } from "azure-pipelines-task-lib/toolrunner";
-import { TerraformCommand, ITerraformProvider, ITaskAgent, TerraformInterfaces, ILogger } from "./terraform";
+import { TerraformCommand, ITaskAgent, TerraformInterfaces, ILogger } from "./terraform";
 import { injectable, inject } from "inversify";
 import { IHandleCommandString } from "./command-handler";
+import { TerraformRunner } from "./terraform-runner";
 
 export class TerraformDestroy extends TerraformCommand{
     readonly secureVarsFile: string | undefined;
@@ -22,16 +22,13 @@ export class TerraformDestroy extends TerraformCommand{
 
 @injectable()
 export class TerraformDestroyHandler implements IHandleCommandString{
-    private readonly terraformProvider: ITerraformProvider;
     private readonly taskAgent: ITaskAgent;
     private readonly log: ILogger;
 
     constructor(
-        @inject(TerraformInterfaces.ITerraformProvider) terraformProvider: ITerraformProvider,
         @inject(TerraformInterfaces.ITaskAgent) taskAgent: ITaskAgent,
         @inject(TerraformInterfaces.ILogger) log: ILogger
     ) {
-        this.terraformProvider = terraformProvider;           
         this.taskAgent = taskAgent;     
         this.log = log;
     }
@@ -54,36 +51,10 @@ export class TerraformDestroyHandler implements IHandleCommandString{
     }
 
     private async onExecute(command: TerraformDestroy): Promise<number> {
-        let terraform: ToolRunner = this.terraformProvider.create(command);
-        if((<any>terraform).args.indexOf("-auto-approve") < 0)
-            terraform.arg("-auto-approve");
-        this.setupAzureRmProvider(command, terraform);
-        await this.setupVars(command, terraform);
-
-        return terraform.exec(<IExecOptions>{
-            cwd: command.workingDirectory
-        });
-    }
-
-    private async setupVars(command: TerraformDestroy, terraform: ToolRunner){
-        if(command.secureVarsFile){
-            const secureFilePath = await this.taskAgent.downloadSecureFile(command.secureVarsFile);
-            terraform.arg(`-var-file=${secureFilePath}`);
-        }
-    }
-
-    private setupAzureRmProvider(command: TerraformDestroy, terraform: ToolRunner){
-        if(command.environmentServiceName){
-            let scheme = tasks.getEndpointAuthorizationScheme(command.environmentServiceName, true);
-            if(scheme != "ServicePrincipal"){
-                throw "Terraform only supports service principal authorization for azure";
-            }
-
-            process.env['ARM_SUBSCRIPTION_ID']  = tasks.getEndpointDataParameter(command.environmentServiceName, "subscriptionid", false);
-            process.env['ARM_TENANT_ID']        = tasks.getEndpointAuthorizationParameter(command.environmentServiceName, "tenantid", false);
-            process.env['ARM_CLIENT_ID']        = tasks.getEndpointAuthorizationParameter(command.environmentServiceName, "serviceprincipalid", false);
-            process.env['ARM_CLIENT_SECRET']    = tasks.getEndpointAuthorizationParameter(command.environmentServiceName, "serviceprincipalkey", false);
-        }
-        
+        return await new TerraformRunner(command)                                    
+            .withAutoApprove()
+            .withAzureRmProvider(command.environmentServiceName)            
+            .withSecureVarsFile(this.taskAgent, command.secureVarsFile)
+            .exec();
     }
 }

--- a/TerraformCLI/src/terraform-error.ts
+++ b/TerraformCLI/src/terraform-error.ts
@@ -1,0 +1,6 @@
+export class TerraformError extends Error {
+    constructor(name: string, message: string) {
+        super(message);
+        this.name = name;
+    }
+}

--- a/TerraformCLI/src/terraform-error.ts
+++ b/TerraformCLI/src/terraform-error.ts
@@ -1,6 +1,9 @@
+import { stat } from "fs";
+
 export class TerraformError extends Error {
-    constructor(name: string, message: string) {
+    constructor(name: string, message: string, stack?: string | undefined) {
         super(message);
         this.name = name;
+        this.stack = stack;
     }
 }

--- a/TerraformCLI/src/terraform-plan.ts
+++ b/TerraformCLI/src/terraform-plan.ts
@@ -1,8 +1,8 @@
 import tasks = require("azure-pipelines-task-lib/task");
-import { IExecOptions, ToolRunner } from "azure-pipelines-task-lib/toolrunner";
-import { TerraformCommand, TerraformInterfaces, ITerraformProvider, ITaskAgent, ILogger } from "./terraform";
+import { TerraformCommand, TerraformInterfaces, ITaskAgent, ILogger } from "./terraform";
 import { IHandleCommandString } from "./command-handler";
 import { injectable, inject } from "inversify";
+import { TerraformRunner } from "./terraform-runner";
 
 export class TerraformPlan extends TerraformCommand{
     readonly secureVarsFile: string | undefined;
@@ -22,16 +22,13 @@ export class TerraformPlan extends TerraformCommand{
 
 @injectable()
 export class TerraformPlanHandler implements IHandleCommandString{
-    private readonly terraformProvider: ITerraformProvider;
     private readonly taskAgent: ITaskAgent;
     private readonly log: ILogger;
 
     constructor(
-        @inject(TerraformInterfaces.ITerraformProvider) terraformProvider: ITerraformProvider,
         @inject(TerraformInterfaces.ITaskAgent) taskAgent: ITaskAgent,
         @inject(TerraformInterfaces.ILogger) log: ILogger
     ) {
-        this.terraformProvider = terraformProvider;        
         this.taskAgent = taskAgent;   
         this.log = log;
     }
@@ -54,24 +51,12 @@ export class TerraformPlanHandler implements IHandleCommandString{
     }
 
     private async onExecute(command: TerraformPlan): Promise<number> {
-        var terraform = this.terraformProvider.create(command);
-        this.setupAzureRmProvider(command, terraform);
-        await this.setupVars(command, terraform);
-        
-        let execOptions: IExecOptions = <IExecOptions>{
-            cwd: command.workingDirectory,
-            // if using detailed exit code, disable automated interpretation of exit codes by the toolrunner so exit code 2 doesn't return error
-            ignoreReturnCode: this.hasDetailedExitCode(command.options)
-        };
-
-        let exitCode = await terraform.exec(execOptions);
+        let exitCode = await new TerraformRunner(command)
+            .withAzureRmProvider(command.environmentServiceName)
+            .withSecureVarsFile(this.taskAgent, command.secureVarsFile)
+            .exec();
 
         this.setPlanHasChangesVariable(command.options, exitCode);
-
-        // ensure exit code 1 still throws error so task result is set to Failed. 
-        if(execOptions.ignoreReturnCode && exitCode === 1){
-            throw "terraform plan failed with exit code 1";
-        }
 
         return exitCode;
     }
@@ -87,27 +72,5 @@ export class TerraformPlanHandler implements IHandleCommandString{
     private setPlanHasChangesVariable(commandOptions: string | undefined, exitCode: number): void{
         let planHasChanges:boolean = exitCode === this.getPlanHasChangesExitCode(commandOptions);
         tasks.setVariable("TERRAFORM_PLAN_HAS_CHANGES", planHasChanges.toString(), false);
-    }
-
-    private async setupVars(command: TerraformPlan, terraform: ToolRunner){
-        if(command.secureVarsFile){
-            const secureFilePath = await this.taskAgent.downloadSecureFile(command.secureVarsFile);
-            terraform.arg(`-var-file=${secureFilePath}`);
-        }
-    }
-
-    private setupAzureRmProvider(command: TerraformPlan, terraform: ToolRunner){
-        if(command.environmentServiceName){
-            let scheme = tasks.getEndpointAuthorizationScheme(command.environmentServiceName, true);
-            if(scheme != "ServicePrincipal"){
-                throw "Terraform only supports service principal authorization for azure";
-            }
-
-            process.env['ARM_SUBSCRIPTION_ID']  = tasks.getEndpointDataParameter(command.environmentServiceName, "subscriptionid", false);
-            process.env['ARM_TENANT_ID']        = tasks.getEndpointAuthorizationParameter(command.environmentServiceName, "tenantid", false);
-            process.env['ARM_CLIENT_ID']        = tasks.getEndpointAuthorizationParameter(command.environmentServiceName, "serviceprincipalid", false);
-            process.env['ARM_CLIENT_SECRET']    = tasks.getEndpointAuthorizationParameter(command.environmentServiceName, "serviceprincipalkey", false);
-        }
-        
     }
 }

--- a/TerraformCLI/src/terraform-runner.ts
+++ b/TerraformCLI/src/terraform-runner.ts
@@ -1,6 +1,7 @@
 import tasks = require("azure-pipelines-task-lib/task");
 import { ToolRunner, IExecSyncOptions } from "azure-pipelines-task-lib/toolrunner";
 import { TerraformCommand, ITaskAgent } from "./terraform";
+import { TerraformAggregateError } from "./terraform-aggregate-error";
 
 export interface TerraformCommandContext {
     terraform: ToolRunner;
@@ -135,7 +136,7 @@ export class TerraformRunner{
             cwd: this.command.workingDirectory
         });
         if(result.stderr){
-            throw new Error(result.stderr);
+            throw new TerraformAggregateError(this.command.name, result.stderr, result.code);
         }
         return result.code;
     }

--- a/TerraformCLI/src/terraform-runner.ts
+++ b/TerraformCLI/src/terraform-runner.ts
@@ -1,0 +1,142 @@
+import tasks = require("azure-pipelines-task-lib/task");
+import { ToolRunner, IExecSyncOptions } from "azure-pipelines-task-lib/toolrunner";
+import { TerraformCommand, ITaskAgent } from "./terraform";
+
+export interface TerraformCommandContext {
+    terraform: ToolRunner;
+    command: TerraformCommand;
+}
+
+export abstract class TerraformCommandBuilder {
+    abstract run(context: TerraformCommandContext): Promise<void>;
+}
+
+export abstract class TerraformCommandDecorator extends TerraformCommandBuilder{
+    protected readonly builder: TerraformCommandBuilder;
+    constructor(builder: TerraformCommandBuilder) {
+        super();
+        this.builder = builder;
+    }
+    async run(context: TerraformCommandContext): Promise<void>{
+        await this.builder.run(context);
+        await this.onRun(context);
+    }
+    abstract onRun(context: TerraformCommandContext): Promise<void>;
+}
+
+export class TerraformWithCommand extends TerraformCommandBuilder{
+    private readonly command: TerraformCommand;
+
+    constructor(command: TerraformCommand) {
+        super();
+        this.command = command;
+    }
+    async run(context: TerraformCommandContext): Promise<void> {
+        if (this.command) {
+            context.terraform.arg(this.command.name);            
+        }
+    }
+}
+
+export class TerraformWithAzureRmProvider extends TerraformCommandDecorator{
+    private readonly environmentServiceName: string;
+    constructor(builder: TerraformCommandBuilder, environmentServiceName: string) {
+        super(builder);
+        this.environmentServiceName = environmentServiceName;
+    }
+    async onRun(context: TerraformCommandContext): Promise<void> {        
+        if(this.environmentServiceName){
+            let scheme = tasks.getEndpointAuthorizationScheme(this.environmentServiceName, true);
+            if(scheme != "ServicePrincipal"){
+                throw "Terraform only supports service principal authorization for azure";
+            }
+
+            process.env['ARM_SUBSCRIPTION_ID']  = tasks.getEndpointDataParameter(this.environmentServiceName, "subscriptionid", false);
+            process.env['ARM_TENANT_ID']        = tasks.getEndpointAuthorizationParameter(this.environmentServiceName, "tenantid", false);
+            process.env['ARM_CLIENT_ID']        = tasks.getEndpointAuthorizationParameter(this.environmentServiceName, "serviceprincipalid", false);
+            process.env['ARM_CLIENT_SECRET']    = tasks.getEndpointAuthorizationParameter(this.environmentServiceName, "serviceprincipalkey", false);
+        }
+    }    
+}
+
+export class TerraformWithAutoApprove extends TerraformCommandDecorator{
+    constructor(builder: TerraformCommandBuilder) {
+        super(builder);
+    }
+    async onRun(context: TerraformCommandContext): Promise<void> {   
+        if(context.command.name !== 'apply' && context.command.name !== 'destroy')
+            throw "'-auto-approve option only valid for commands apply and destroy";
+        const autoApproveOption = "-auto-approve";
+        if(!context.command.options || (context.command.options && context.command.options.includes(autoApproveOption) === false)){
+            context.terraform.arg(autoApproveOption);
+        }
+    }
+}
+
+export class TerraformWithSecureVarFile extends TerraformCommandDecorator{    
+    private readonly taskAgent: ITaskAgent;
+    private readonly secureVarFileId: string | undefined;
+    constructor(builder: TerraformCommandBuilder, taskAgent: ITaskAgent, secureVarFileId?: string | undefined) {
+        super(builder);
+        this.taskAgent = taskAgent;
+        this.secureVarFileId = secureVarFileId;
+    }
+    async onRun(context: TerraformCommandContext): Promise<void> {        
+        if(this.secureVarFileId){
+            const secureFilePath = await this.taskAgent.downloadSecureFile(this.secureVarFileId);
+            context.terraform.arg(`-var-file=${secureFilePath}`);
+        }
+    }
+}
+
+export class TerraformRunner{
+    private readonly terraform: ToolRunner;
+    private readonly terraformPath: string;
+    public readonly command: TerraformCommand;
+    private builder: TerraformCommandBuilder;    
+
+    constructor(command: TerraformCommand) {
+        this.terraformPath = tasks.which("terraform", true);
+        this.terraform = tasks.tool(this.terraformPath);
+        this.command = command;
+        this.builder = new TerraformWithCommand(command);
+    }
+
+    with(decoratorFactory: (builder: TerraformCommandBuilder) => TerraformCommandBuilder): TerraformRunner{
+        this.builder = decoratorFactory(this.builder);
+        return this;
+    }
+
+    withAzureRmProvider(environmentServiceName: string): TerraformRunner{
+        this.builder = new TerraformWithAzureRmProvider(this.builder, environmentServiceName);
+        return this;
+    }
+
+    withAutoApprove(): TerraformRunner{
+        this.builder = new TerraformWithAutoApprove(this.builder);
+        return this;
+    }
+
+    withSecureVarsFile(taskAgent: ITaskAgent, secureVarFileId?: string | undefined): TerraformRunner{
+        return this.with((builder) => new TerraformWithSecureVarFile(builder, taskAgent, secureVarFileId));
+    }
+
+    async exec(): Promise<number>{
+        await this.builder.run(<TerraformCommandContext>{
+            terraform: this.terraform,
+            command: this.command
+        });
+
+        // append the user provided options last.
+        if (this.command.options) {
+            this.terraform.line(this.command.options);
+        }
+        let result = this.terraform.execSync(<IExecSyncOptions>{
+            cwd: this.command.workingDirectory
+        });
+        if(result.stderr){
+            throw new Error(result.stderr);
+        }
+        return result.code;
+    }
+}

--- a/TerraformCLI/src/terraform-version.ts
+++ b/TerraformCLI/src/terraform-version.ts
@@ -1,20 +1,15 @@
-import { TerraformInterfaces, ITerraformProvider } from "./terraform";
+import tasks = require("azure-pipelines-task-lib/task");
+import { TerraformCommand } from "./terraform";
 import { IHandleCommandString } from "./command-handler";
-import { injectable, inject } from "inversify";
+import { injectable } from "inversify";
+import { TerraformRunner } from "./terraform-runner";
 
 @injectable()
 export class TerraformVersionHandler implements IHandleCommandString{
-    private readonly terraformProvider: ITerraformProvider;
-
-    constructor(
-        @inject(TerraformInterfaces.ITerraformProvider) terraformProvider: ITerraformProvider
-    ) {
-        this.terraformProvider = terraformProvider;   
-    }
-
     public async execute(command: string): Promise<number> {
-        var terraform = this.terraformProvider.create();
-        terraform.arg(command);
-        return terraform.exec();
+        return new TerraformRunner(
+            new TerraformCommand("version", tasks.getInput("workingDirectory"))
+        )
+        .exec();
     }
 }

--- a/TerraformCLI/src/terraform.ts
+++ b/TerraformCLI/src/terraform.ts
@@ -1,7 +1,3 @@
-import { injectable } from 'inversify';
-import { ToolRunner } from "azure-pipelines-task-lib/toolrunner";
-import { PullRequestSystemType } from 'azure-devops-node-api/interfaces/ReleaseInterfaces';
-
 export class TerraformCommand {
     public readonly name: string;
     public readonly options: string | undefined;
@@ -16,31 +12,6 @@ export class TerraformCommand {
     }
 }
 
-export interface ITerraformProvider {
-    create(command?: TerraformCommand): ToolRunner
-}
-
-@injectable()
-export class TerraformProvider implements ITerraformProvider {
-    private readonly tasks: any;
-    constructor(tasks: any) {
-        this.tasks = tasks
-    }
-
-    public create(command?: TerraformCommand): ToolRunner {
-        let terraformPath = this.tasks.which("terraform", true);
-        let terraform: ToolRunner = this.tasks.tool(terraformPath);
-        if (command) {
-            terraform.arg(command.name);
-            if (command.options) {
-                terraform.line(command.options);
-            }
-        }
-
-        return terraform;
-    }
-}
-
 export interface ITaskAgent {
     downloadSecureFile(secureFileId: string): Promise<string>
 }
@@ -52,7 +23,6 @@ export interface ILogger {
 }
 
 export const TerraformInterfaces = {
-    ITerraformProvider: Symbol("ITerraformProvider"),
     ITaskAgent: Symbol('ITaskAgent'),
     ILogger: Symbol('ILogger')
 }


### PR DESCRIPTION
The following changes will allow errors written to stderr to be formated to typed errors which can then be output in a more readable/searchable format to application insights. This will also allow azure devops pipelines to show better error summary when the task fails (instead of terraform exited with code 1).

This change refactors the handlers to use a new module TerraformRunner. This follows the pattern established with the az-runner for azure cli. This allows for centralized formatting/processing of IExecSyncResult, In this case, it provides a place where the stderr of all commands can be formatted.