### PR TITLE
Dont fail when stderr defined but exit code is successful

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,18 @@ See readme for each of the tasks for development setup for each.
 
 ## Release Notes
 
+### 0.4.13
+
+Fixed issue where task would fail when using TF_LOG debug variable. When this variable was used, logging would be written to stderr even when the command was successful (i.e. exit code 0). This would cause the task to decide the command failed due to the existence of content in stderr. The fix changes the decision to be based of the exit code. This should allow for TF_LOG to be used and the task succeed when the underlying command succeeds.
+
+### 0.4.12
+
+Parse errors from stderr output and write to exception telemetry.
+
+### 0.4.11
+
+Record which command option flags were used during execution without values in telemetry.
+
 ### 0.4.10
 
 #### Added pipeline variables that indicate last exit code and indicate if plan detected changes

--- a/TerraformCLI/src/terraform-aggregate-error.ts
+++ b/TerraformCLI/src/terraform-aggregate-error.ts
@@ -3,6 +3,7 @@ import { TerraformError } from "./terraform-error";
 export class TerraformAggregateError extends Error {
     public readonly errors: TerraformError[];
     public readonly stderr: string;
+    public readonly exitCode: number;
     constructor(command: string, stderr: string, exitCode: number) {
         let stderrEscaped: string = stderr
         .replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '');
@@ -17,8 +18,9 @@ export class TerraformAggregateError extends Error {
             .join(" | ");
         super(message);
         this.stderr = stderrEscaped;
-        this.name = `Terraform command '${command}' failed with exit code '${exitCode}.`;
+        this.name = `Terraform command '${command}' failed with exit code '${exitCode}'.`;
         this.errors = [];
+        this.exitCode = exitCode;
         lines.forEach((line, i) => {
             if (line.startsWith('Error:')) {
                 let name: string = line.replace('Error: ', '');

--- a/TerraformCLI/src/terraform-plan.ts
+++ b/TerraformCLI/src/terraform-plan.ts
@@ -54,11 +54,19 @@ export class TerraformPlanHandler implements IHandleCommandString{
         let exitCode = await new TerraformRunner(command)
             .withAzureRmProvider(command.environmentServiceName)
             .withSecureVarsFile(this.taskAgent, command.secureVarsFile)
-            .exec();
+            .exec(this.getPlanSuccessfulExitCodes(command.options));
 
         this.setPlanHasChangesVariable(command.options, exitCode);
 
         return exitCode;
+    }
+
+    private getPlanSuccessfulExitCodes(commandOptions: string | undefined): number[]{
+        let rvalues: number[] = [];
+        rvalues.push(0);
+        if(this.hasDetailedExitCode(commandOptions))
+            rvalues.push(2);
+        return rvalues;
     }
 
     private hasDetailedExitCode(commandOptions: string | undefined): boolean{

--- a/TerraformCLI/src/tests/scenarios-terraform.ts
+++ b/TerraformCLI/src/tests/scenarios-terraform.ts
@@ -14,7 +14,7 @@ declare module "./scenarios"{
         inputAzureRmEnsureBackend(this: TaskScenario<TerraformInputs>, resourceGroupLocation?: string, storageAccountSku?: string): TaskScenario<TerraformInputs>;
         inputApplicationInsightsInstrumentationKey(this: TaskScenario<TerraformInputs>, instrumentationKey?: string): TaskScenario<TerraformInputs>;
         answerTerraformExists(this: TaskScenario<TerraformInputs>, terraformExists?: boolean): TaskScenario<TerraformInputs>;
-        answerTerraformCommandIsSuccessful(this: TaskScenario<TerraformInputs>, args?: string, exitCode?: number): TaskScenario<TerraformInputs>;
+        answerTerraformCommandIsSuccessful(this: TaskScenario<TerraformInputs>, args?: string, exitCode?: number, stderr?: string): TaskScenario<TerraformInputs>;
         answerTerraformCommandWithVarsFileAsWorkingDirFails(this: TaskScenario<TerraformInputs>): TaskScenario<TerraformInputs>;
         answerAzExists(this: TaskScenario<TerraformInputs>, azExists?: boolean): TaskScenario<TerraformInputs>;
         answerAzCommandIsSuccessfulWithResultRaw<TCommand extends ICommand<TResult>, TResult>(this: TaskScenario<TerraformInputs>, command: TCommand, result: string): TaskScenario<TerraformInputs>;
@@ -135,10 +135,12 @@ TaskScenario.prototype.answerTerraformCommandWithVarsFileAsWorkingDirFails = fun
 export class TerraformCommandIsSuccessful extends TaskAnswerDecorator<TerraformInputs>{
     private readonly args: string | undefined;
     private readonly exitCode: number | undefined;
-    constructor(builder: TaskAnswerBuilder<TerraformInputs>, args?: string, exitCode?: number) {
+    private readonly stderr: string | undefined;
+    constructor(builder: TaskAnswerBuilder<TerraformInputs>, args?: string, exitCode?: number, stderr?: string) {
         super(builder);
         this.args = args;
         this.exitCode = exitCode;
+        this.stderr = stderr;
     }
     build(inputs: TerraformInputs): TaskLibAnswers {
         let a = this.builder.build(inputs);
@@ -156,13 +158,14 @@ export class TerraformCommandIsSuccessful extends TaskAnswerDecorator<TerraformI
 
         a.exec[command] = <TaskLibAnswerExecResult>{
             code : this.exitCode || 0,
-            stdout : `${inputs.command} successful`
+            stdout : `${inputs.command} successful`,
+            stderr : this.stderr
         }
         return a;
     }
 }
-TaskScenario.prototype.answerTerraformCommandIsSuccessful = function(this: TaskScenario<TerraformInputs>, args?: string, exitCode?: number): TaskScenario<TerraformInputs>{
-    this.answerFactory((builder) => new TerraformCommandIsSuccessful(builder, args, exitCode));
+TaskScenario.prototype.answerTerraformCommandIsSuccessful = function(this: TaskScenario<TerraformInputs>, args?: string, exitCode?: number, stderr?: string): TaskScenario<TerraformInputs>{
+    this.answerFactory((builder) => new TerraformCommandIsSuccessful(builder, args, exitCode, stderr));
     return this;
 }
 

--- a/TerraformCLI/src/tests/terraform/terraform-populates-stderr-on-success.ts
+++ b/TerraformCLI/src/tests/terraform/terraform-populates-stderr-on-success.ts
@@ -1,0 +1,10 @@
+import { TaskScenario } from '../scenarios';
+import { TerraformInputs } from '../scenarios-terraform';
+import '../scenarios-terraform'
+
+new TaskScenario<TerraformInputs>()
+    .inputTerraformCommand("version")
+    .inputApplicationInsightsInstrumentationKey()
+    .answerTerraformExists(true)
+    .answerTerraformCommandIsSuccessful(undefined, 0, "some err")
+    .run();

--- a/TerraformCLI/src/tests/terraform/terraform_spec.ts
+++ b/TerraformCLI/src/tests/terraform/terraform_spec.ts
@@ -7,4 +7,9 @@ describe('terraform', function(){
             .assertExecutionFailed()
             .run();
     });
+    it('terraform populates stderr on success', function(){
+        new TestScenario(require.resolve('./terraform-populates-stderr-on-success'))
+            .assertExecutionSucceeded()
+            .run();
+    });
 });


### PR DESCRIPTION
This fixes the issue reported in #77 

The root cause was that the task was incorrectly assuming the existence of stderr equals failure. There appears to be cases where terraform providers will write to stderr even when successful.

This change resolves the issue by determining success based on provided successful exit codes. If the resulting exit code does not equal one of the successful exit codes, then an error will be thrown. Otherwise, the task will assume the command was successful. If no successful exit codes are provided, then zero is assumed to be a successful exit code.