### PR TITLE
prevent failure when warnings are written to stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ See readme for each of the tasks for development setup for each.
 
 ## Release Notes
 
+### 0.4.20
+
+Fixed issue where azure cli operations (used to ensure backend exists) interpreted warnings as failures. Azure cli will write warnings to stderr while keeping exit code 0. In this condition, the task will no longer fail.
+
 ### 0.4.16
 
 Add support for secure .env files. Secure variable files chosen that end in `.env` will be treated as .env files. The environment variables within the file will be emitted to the task process so that they are available to terraform.

--- a/TerraformCLI/src/az-runner.ts
+++ b/TerraformCLI/src/az-runner.ts
@@ -1,5 +1,4 @@
 import { ToolRunner } from "azure-pipelines-task-lib/toolrunner";
-import * as tasks from 'azure-pipelines-task-lib/task';
 import { injectable } from "inversify";
 
 @injectable()
@@ -23,7 +22,7 @@ export class AzRunner {
         if(result.code !== 0 && result.stderr)
             throw new Error(result.stderr);
         else if(result.code === 0 && result.stderr && result.stderr.startsWith("WARNING"))
-            tasks.warning(result.stderr);
+            this.tasks.warning(result.stderr);
 
         let rvalue: T = <T>JSON.parse(result.stdout);
         return rvalue;

--- a/TerraformCLI/src/az-runner.ts
+++ b/TerraformCLI/src/az-runner.ts
@@ -1,4 +1,5 @@
 import { ToolRunner } from "azure-pipelines-task-lib/toolrunner";
+import * as tasks from 'azure-pipelines-task-lib/task';
 import { injectable } from "inversify";
 
 @injectable()
@@ -18,9 +19,11 @@ export class AzRunner {
 
         cli.line(line);
         let result = cli.execSync();
-        
-        if(result.stderr)
+
+        if(result.code !== 0 && result.stderr)
             throw new Error(result.stderr);
+        else if(result.code === 0 && result.stderr && result.stderr.startsWith("WARNING"))
+            tasks.warning(result.stderr);
 
         let rvalue: T = <T>JSON.parse(result.stdout);
         return rvalue;

--- a/TerraformCLI/src/tests/scenarios-terraform.ts
+++ b/TerraformCLI/src/tests/scenarios-terraform.ts
@@ -17,8 +17,8 @@ declare module "./scenarios"{
         answerTerraformCommandIsSuccessful(this: TaskScenario<TerraformInputs>, args?: string, exitCode?: number, stderr?: string): TaskScenario<TerraformInputs>;
         answerTerraformCommandWithVarsFileAsWorkingDirFails(this: TaskScenario<TerraformInputs>): TaskScenario<TerraformInputs>;
         answerAzExists(this: TaskScenario<TerraformInputs>, azExists?: boolean): TaskScenario<TerraformInputs>;
-        answerAzCommandIsSuccessfulWithResultRaw<TCommand extends ICommand<TResult>, TResult>(this: TaskScenario<TerraformInputs>, command: TCommand, result: string): TaskScenario<TerraformInputs>;
-        answerAzCommandIsSuccessfulWithResult<TCommand extends ICommand<TResult>, TResult>(this: TaskScenario<TerraformInputs>, command: TCommand, result: TResult): TaskScenario<TerraformInputs>;
+        answerAzCommandIsSuccessfulWithResultRaw<TCommand extends ICommand<TResult>, TResult>(this: TaskScenario<TerraformInputs>, command: TCommand, result: string, warning?: string): TaskScenario<TerraformInputs>;
+        answerAzCommandIsSuccessfulWithResult<TCommand extends ICommand<TResult>, TResult>(this: TaskScenario<TerraformInputs>, command: TCommand, result: TResult, warning?: string): TaskScenario<TerraformInputs>;
         answerAzCommandFailsWithErrorRaw<TCommand extends ICommand<TResult>, TResult>(this: TaskScenario<TerraformInputs>, command: TCommand, error: string): TaskScenario<TerraformInputs>;
     }
 }
@@ -232,10 +232,12 @@ TaskScenario.prototype.answerAzExists = function(this: TaskScenario<TerraformInp
 export class AzCommandIsSuccessfulWithResultRaw<TCommand extends ICommand<TResult>, TResult> extends TaskAnswerDecorator<TerraformInputs>{
     private readonly command: TCommand;
     private readonly result: string;
-    constructor(builder: TaskAnswerBuilder<TerraformInputs>, command: TCommand, result: string) {
+    private readonly warning: string;
+    constructor(builder: TaskAnswerBuilder<TerraformInputs>, command: TCommand, result: string, warning: string = "") {
         super(builder);
         this.command = command;
         this.result = result;
+        this.warning = warning;
     }
     build(inputs: TerraformInputs): TaskLibAnswers {
         let a = this.builder.build(inputs);        
@@ -243,22 +245,23 @@ export class AzCommandIsSuccessfulWithResultRaw<TCommand extends ICommand<TResul
         let command = `az ${this.command.toString()}`;
         a.exec[command] =  <TaskLibAnswerExecResult>{
             code: 0,
-            stdout: this.result
+            stdout: this.result,
+            stderr: this.warning
         }
         return a;
     }
 }
-TaskScenario.prototype.answerAzCommandIsSuccessfulWithResultRaw = function<TCommand extends ICommand<TResult>, TResult>(this: TaskScenario<TerraformInputs>, command: TCommand, result: string): TaskScenario<TerraformInputs>{    
-    return this.answerFactory((builder) => new AzCommandIsSuccessfulWithResultRaw<TCommand, TResult>(builder, command, result));
+TaskScenario.prototype.answerAzCommandIsSuccessfulWithResultRaw = function<TCommand extends ICommand<TResult>, TResult>(this: TaskScenario<TerraformInputs>, command: TCommand, result: string, warning: string = ""): TaskScenario<TerraformInputs>{    
+    return this.answerFactory((builder) => new AzCommandIsSuccessfulWithResultRaw<TCommand, TResult>(builder, command, result, warning));
 }
 
 export class AzCommandIsSuccessfulWithResult<TCommand extends ICommand<TResult>, TResult> extends AzCommandIsSuccessfulWithResultRaw<TCommand, TResult>{
-    constructor(builder: TaskAnswerBuilder<TerraformInputs>, command: TCommand, result: TResult) {
-        super(builder, (command), JSON.stringify(result));
+    constructor(builder: TaskAnswerBuilder<TerraformInputs>, command: TCommand, result: TResult, warning: string = "") {
+        super(builder, (command), JSON.stringify(result), warning);
     }
 }
-TaskScenario.prototype.answerAzCommandIsSuccessfulWithResult = function<TCommand extends ICommand<TResult>, TResult>(this: TaskScenario<TerraformInputs>, command: TCommand, result: TResult): TaskScenario<TerraformInputs>{
-    return this.answerFactory((builder) => new AzCommandIsSuccessfulWithResult<TCommand, TResult>(builder, command, result));
+TaskScenario.prototype.answerAzCommandIsSuccessfulWithResult = function<TCommand extends ICommand<TResult>, TResult>(this: TaskScenario<TerraformInputs>, command: TCommand, result: TResult, warning: string = ""): TaskScenario<TerraformInputs>{
+    return this.answerFactory((builder) => new AzCommandIsSuccessfulWithResult<TCommand, TResult>(builder, command, result, warning));
 }
 
 export class AzCommandFailsWithErrorRaw<TCommand extends ICommand<TResult>, TResult> extends TaskAnswerDecorator<TerraformInputs>{

--- a/TerraformCLI/src/tests/terraform-init/init-with-backend-azurerm-with-ensure-backend.ts
+++ b/TerraformCLI/src/tests/terraform-init/init-with-backend-azurerm-with-ensure-backend.ts
@@ -28,5 +28,9 @@ new TaskScenario<TerraformInputs>()
     )
     .answerAzCommandIsSuccessfulWithResult(new AzStorageAccountCreate(env.backendStorageAccountName, env.backendResourceGroupName, env.backendStorageAccountSku), <AzStorageAccountCreateResult>{})
     .answerAzCommandIsSuccessfulWithResultRaw(new AzStorageAccountKeysList(env.backendStorageAccountName, env.backendResourceGroupName), JSON.stringify([new AzStorageAccountKey("primary", "full", env.backendKey)]))
-    .answerAzCommandIsSuccessfulWithResult(new AzStorageContainerCreate(env.backendContainerName, env.backendStorageAccountName), <AzStorageAccountCreateResult>{})
+    .answerAzCommandIsSuccessfulWithResult(
+        new AzStorageContainerCreate(env.backendContainerName, env.backendStorageAccountName), 
+        <AzStorageAccountCreateResult>{},
+        "WARNING: No connection string, account key or sas token found, we will query account keys for your storage account. Please try to use --auth-mode login or provide one of the following parameters: connection string, account key or sas token for your storage account."
+    )
     .run()


### PR DESCRIPTION
This change will prevent task failure when the azure cli writes content to stderr stream but, still returns exit code zero.

This is to alleviate the issue reported with #106 where a warning is generated due to --auth-mode login not being provided but is assumed. The task fails when this warning is emitted due to the current implementation failing when anything is provided to std err. 

With this change, the warning in #106 will no longer result in task failure.

This should also help with the failure reported in #91 