### PR TITLE
Explicitly set auth-mode on container create

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ See readme for each of the tasks for development setup for each.
 
 ## Release Notes
 
+### 0.4.21
+
+Fixed issue where warning was occurring during ensure backend operation related to `--auth-mode login` not being provided to azure cli. The auth mode will now be provided to prevent the warning message. The specific warning resolved is below.
+
+```text
+WARNING: No connection string, account key or sas token found, we will query account keys for your storage account. Please try to use --auth-mode login or provide one of the following parameters: connection string, account key or sas token for your storage account.
+```
+
 ### 0.4.20
 
 Fixed issue where azure cli operations (used to ensure backend exists) interpreted warnings as failures. Azure cli will write warnings to stderr while keeping exit code 0. In this condition, the task will no longer fail.

--- a/TerraformCLI/src/az-storage-container-create.ts
+++ b/TerraformCLI/src/az-storage-container-create.ts
@@ -30,7 +30,7 @@ export class AzStorageContainerCreate implements ICommand<AzStorageContainerCrea
     }
 
     toString() : string {
-        return `storage container create --name ${this.name} --account-name ${this.accountName}`;
+        return `storage container create --auth-mode login --name ${this.name} --account-name ${this.accountName}`;
     }
 }
 


### PR DESCRIPTION
This should prevent the warning causing the task to fail in #106. This will explicitly tell the command to lookup the access keys to the storage account using the SPN.

The newer versions of the azure cli will write warning to stderr if auth mode is not set when access keys are not provided