### PR TITLE
fixed sample terraform templates to be compatible with azurerm 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ See readme for each of the tasks for development setup for each.
 
 ## Release Notes
 
+### 0.4.22
+
+Fixed [issue #112](https://github.com/charleszipp/azure-pipelines-tasks-terraform/issues/112) where the sample templates within `TerraformTemplates/sample` are throwing an error when using the 2.0.0 version of the azurerm provider
+
+```shell
+"features": required field is not set
+```
+
 ### 0.4.21
 
 Fixed issue where warning was occurring during ensure backend operation related to `--auth-mode login` not being provided to azure cli. The auth mode will now be provided to prevent the warning message. The specific warning resolved is below.

--- a/TerraformTemplates/sample/main.tf
+++ b/TerraformTemplates/sample/main.tf
@@ -1,4 +1,6 @@
 provider "azurerm"{
+  version = "=2.0.0"
+  features {}
 }
 
 terraform{

--- a/TerraformTemplates/sample/main.tf
+++ b/TerraformTemplates/sample/main.tf
@@ -1,8 +1,9 @@
-provider "azurerm"{
-  version = "=2.0.0"
-  features {}
+provider "azurerm" {
+    features {
+    }
 }
 
-terraform{
-    backend "azurerm"{}
+terraform {
+  backend "azurerm" {}
 }
+

--- a/TerraformTemplates/sample/sample.tf
+++ b/TerraformTemplates/sample/sample.tf
@@ -1,4 +1,8 @@
 resource "azurerm_resource_group" "rg" {
-    name = "${join("-", list("rg", var.app-short-name, var.env-short-name, var.region))}"
-    location = "${var.region}"
+  name = join(
+    "-",
+    ["rg", var.app-short-name, var.env-short-name, var.region],
+  )
+  location = var.region
 }
+

--- a/TerraformTemplates/sample/variables.tf
+++ b/TerraformTemplates/sample/variables.tf
@@ -1,14 +1,15 @@
 variable "region" {
-    type = "string"
-    description = "Primary region to which the tracing resources are deployed."
+  type        = string
+  description = "Primary region to which the tracing resources are deployed."
 }
 
 variable "app-short-name" {
-    type = "string"
-    description = "An abbreviated version of the application name."
+  type        = string
+  description = "An abbreviated version of the application name."
 }
 
 variable "env-short-name" {
-    type = "string"
-    description = "An abbreviated version of the environment name."
+  type        = string
+  description = "An abbreviated version of the environment name."
 }
+

--- a/TerraformTemplates/sample/versions.tf
+++ b/TerraformTemplates/sample/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Resolves the issue mentioned in #112 by adding the required feature field and explicitly setting the version.

This also updated the templates using the `terraform 0.12upgrade` command documented [here](https://www.terraform.io/upgrade-guides/0-12.html). 