### PR TITLE
Switch to releasing on new tag

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,8 +1,8 @@
-next-version: 0.1.8
-branches:
+next-version: 0.5.0
+mode: ContinuousDelivery
+branches: 
   pull-request:
-    regex: (pull|pull\-requests|pr)[/-]
-    mode: ContinuousDeployment
-    tag: pr
+      tag: pr
 ignore:
   sha: []
+merge-message-formats: {}


### PR DESCRIPTION
Switches the GitVer versioning mode to ContinuousDelivery. This will change the versioning model to only increment after tagged release.