### PR TITLE
Introduce 'latest' support for TerraformInstaller

### DIFF
--- a/TerraformInstaller/package.json
+++ b/TerraformInstaller/package.json
@@ -28,6 +28,7 @@
   },
   "homepage": "https://github.com/charleszipp/azure-pipelines-tasks-terraform#readme",
   "dependencies": {
+    "node-fetch": "^2.6.0",
     "vsts-task-lib": "^2.7.0",
     "vsts-task-tool-lib": "^0.10.0"
   },

--- a/TerraformInstaller/src/installer.ts
+++ b/TerraformInstaller/src/installer.ts
@@ -12,7 +12,7 @@ const terraformToolName = "terraform";
 export async function download(inputVersion: string): Promise<string>{
     var latestVersion: string = "";
 
-    if(inputVersion == 'latest') {
+    if(inputVersion.toLowerCase() === 'latest') {
         console.log("Getting latest version");
         await fetch('https://checkpoint-api.hashicorp.com/v1/check/terraform')
             .then((response: { json: () => any; }) => response.json())
@@ -25,16 +25,16 @@ export async function download(inputVersion: string): Promise<string>{
     }
     var version = latestVersion != "" ? sanitizeVersion(latestVersion) : sanitizeVersion(inputVersion);
     var cachedToolPath = tools.findLocalTool(terraformToolName, version);
-    if(!cachedToolPath){        
+    if(!cachedToolPath){
         var url = getDownloadUrl(version);
         console.log("Terraform not installed, downloading from: ", url);
         var fileName = `${terraformToolName}-${version}-${uuidV4()}.zip`;
         console.log("Terraform file name as: ", fileName);
-        try{                        
+        try{
             var downloadPath = await tools.downloadTool(url, fileName);
             console.log("Terraform downloaded to path: ", downloadPath);
         }
-        catch (exception){            
+        catch (exception){
             throw new Error(`Terraform download from url '${url}' failed with exception '${exception}'`);
         }
 
@@ -69,7 +69,7 @@ function getDownloadUrl(version: string): string {
         case 'Linux':
             return format(url, "linux");
         case 'Darwin':
-            return format(url, "darwin");        
+            return format(url, "darwin");
         case 'Windows_NT':
             return format(url, "windows");
         default:

--- a/TerraformInstaller/src/installer.ts
+++ b/TerraformInstaller/src/installer.ts
@@ -6,10 +6,24 @@ import * as fs from 'fs';
 import * as os from 'os';
 import { format } from 'util';
 const uuidV4 = require('uuid/v4');
+const fetch = require('node-fetch');
 const terraformToolName = "terraform";
 
 export async function download(inputVersion: string): Promise<string>{
-    var version = sanitizeVersion(inputVersion);
+    var latestVersion: string = "";
+
+    if(inputVersion == 'latest') {
+        console.log("Getting latest version");
+        await fetch('https://checkpoint-api.hashicorp.com/v1/check/terraform')
+            .then((response: { json: () => any; }) => response.json())
+            .then((data: { [x: string]: any; }) => {
+                latestVersion = data.current_version;
+            })
+            .catch((err: any) => {
+                throw new Error(`Unable to retrieve latest version: ${err}`)
+            })
+    }
+    var version = latestVersion != "" ? sanitizeVersion(latestVersion) : sanitizeVersion(inputVersion);
     var cachedToolPath = tools.findLocalTool(terraformToolName, version);
     if(!cachedToolPath){        
         var url = getDownloadUrl(version);

--- a/TerraformInstaller/task.json
+++ b/TerraformInstaller/task.json
@@ -23,7 +23,7 @@
       "name": "terraformVersion",
       "type": "string",
       "label": "Version",
-      "defaultValue": "0.12.20",
+      "defaultValue": "latest",
       "required": true,
       "helpMarkDown": "Specify the version of terraform that should be installed"
     }


### PR DESCRIPTION
This uses Hashi's API for determining latest terraform version. Although
they aren't super happy with this, they use it also in their Terraform
Enterprise offering ;)

Fixes #60