### PR TITLE
Init self configured

### DIFF
--- a/TerraformCLI/README.md
+++ b/TerraformCLI/README.md
@@ -9,7 +9,7 @@ This tasks enables running terraform cli commands from Azure Devops Build and Re
 - import
 - refresh
 
-Terraform is required to exist on the build agent prior to running this task. See TerraformInstaller task within this repository to install terraform. 
+Terraform is required to exist on the build agent prior to running this task. See TerraformInstaller task within this repository to install terraform.
 
 ** If using hosted Ubuntu build agent, terraform installation should NOT be required as terraform is already installed on these agents.
 ## Development Setup
@@ -35,12 +35,12 @@ The example below contains all the possible inputs the task supports
 
 ```shell
 # These indicate where the task will create installed tools and temp files
-# These can remain as-is. 
+# These can remain as-is.
 AGENT_TOOLSDIRECTORY=./../_test-agent/tools
 AGENT_TEMPDIRECTORY=./../_test-agent/temp
 
-# These settings are needed to access secure files that are uploaded to Pipelines > Library > Secure Files. 
-# The connection handshake is currently happening when the task starts. 
+# These settings are needed to access secure files that are uploaded to Pipelines > Library > Secure Files.
+# The connection handshake is currently happening when the task starts.
 # This means these settings currently have to be in place when running locally even if you did not specify a secure file
 # The azure devops url to your target or (i.e. https://dev.azure.com/chzipp)
 SYSTEM_TEAMFOUNDATIONCOLLECTIONURI=my-azure-devops-org-url
@@ -69,7 +69,7 @@ ENDPOINT_AUTH_PARAMETER_dev_TENANTID=my-target-env-tenant-id
 ENDPOINT_AUTH_PARAMETER_dev_SERVICEPRINCIPALID=my-target-env-service-principal-app-id
 ENDPOINT_AUTH_PARAMETER_dev_SERVICEPRINCIPALKEY=my-target-env-service-principal-key
 
-# Indicates what type of terraform backend to use. Current valid values are 'local', 'azurerm'. 
+# Indicates what type of terraform backend to use. Current valid values are 'local', 'azurerm'.
 INPUT_BACKENDTYPE=local
 
 # If using 'azurerm' backend, this is the service name to the tfstate storage account's subscription
@@ -103,7 +103,7 @@ TerraformTemplates/sample/main.tf
 terraform{
     backend "azurerm"{}
 }
-``` 
+```
 ## Compile
 The `npm run build` script will compile the typescript down to standard es6 javascript
 ```

--- a/TerraformCLI/task.json
+++ b/TerraformCLI/task.json
@@ -108,7 +108,8 @@
             "helpMarkDown": "Select the terraform backend type to use.",
             "options": {
                 "local": "local",
-                "azurerm": "azurerm"
+                "azurerm": "azurerm",
+                "selfConfigured": "self-configured"
             },
             "properties": {
                 "EditableOptions": "False"

--- a/TerraformCLI/task.json
+++ b/TerraformCLI/task.json
@@ -105,7 +105,7 @@
             "label": "Backend Type",
             "defaultValue": "local",
             "required": false,
-            "helpMarkDown": "Select the terraform backend type to use.",
+            "helpMarkDown": "Select the terraform backend type to use. Select self-configured if your backend configuration is expected to be set via environment variables or command options. Environment files can be provided using Secure Files Library in AzDO and specified in Secure Files configuration field. Command options such as `-backend-config=` flag can be provided in the Command Options configuration field.",
             "options": {
                 "local": "local",
                 "azurerm": "azurerm",

--- a/overview.md
+++ b/overview.md
@@ -40,12 +40,13 @@ When executing `plan`, `apply`, `destroy`, and `refresh` commands, the task will
 
 ![Terraform Azure Environment Subscription](https://raw.githubusercontent.com/charleszipp/azure-pipelines-tasks-terraform/master/screenshots/overview-tfcli-azure-sub.jpg)
 
-## Remote & Local Backend State Support
+## Remote, Local and Self-configured Backend State Support
 
-The task currently supports two backend configurations
+The task currently supports the following backend configurations
 
 - local (default for terraform) - State is stored on the agent file system.
 - azurerm - State is stored in a blob container within a specified Azure Storage Account.
+- self-configured - State configuration will be provided using environment variables or command options. Environment files can be provided using Secure Files Library in AzDO and specified in Secure Files configuration field. Command options such as `-backend-config=` flag can be provided in the Command Options configuration field.
 
 The backend configuration will be prompted when relevant for the selected command. If azurerm selected, the task will prompt for a service connection and storage account details to use for the backend.
 
@@ -63,7 +64,7 @@ There are three methods to provide secrets within the vars provided to terraform
 
 ### Secure Env Files (NEW)
 
-If the Secure Variables file name is `*.env`, it is referred as `.env` file. This task loads environment variables from the `.env` file.  
+If the Secure Variables file name is `*.env`, it is referred as `.env` file. This task loads environment variables from the `.env` file.
 
 #### _.env file example_
 


### PR DESCRIPTION
Doesn't do much now, same as local :) Also renamed `withAzureRmBackend` to `withBackend`, since we don't assume backend to be azurerm anymore.