### PR TITLE
Make backend compatible with 0.11 versions

### DIFF
--- a/TerraformCLI/src/terraform-init.ts
+++ b/TerraformCLI/src/terraform-init.ts
@@ -22,10 +22,10 @@ export interface AzureBackendConfig {
     container_name          : string,
     key                     : string,
     resource_group_name     : string,
-    subscription_id         : string,
-    tenant_id               : string,
-    client_id               : string,
-    client_secret           : string
+    arm_subscription_id     : string,
+    arm_tenant_id           : string,
+    arm_client_id           : string,
+    arm_client_secret       : string
 }
 
 export class TerraformInit extends TerraformCommand{
@@ -78,10 +78,10 @@ export class TerraformWithBackend extends TerraformCommandDecorator{
                 container_name          : tasks.getInput("backendAzureRmContainerName", true),
                 key                     : tasks.getInput("backendAzureRmKey", true),
                 resource_group_name     : tasks.getInput("backendAzureRmResourceGroupName", true),
-                subscription_id         : tasks.getEndpointDataParameter(backendServiceName, "subscriptionid", true),
-                tenant_id               : tasks.getEndpointAuthorizationParameter(backendServiceName, "tenantid", true),
-                client_id               : tasks.getEndpointAuthorizationParameter(backendServiceName, "serviceprincipalid", true),
-                client_secret           : tasks.getEndpointAuthorizationParameter(backendServiceName, "serviceprincipalkey", true)
+                arm_subscription_id     : tasks.getEndpointDataParameter(backendServiceName, "subscriptionid", true),
+                arm_tenant_id           : tasks.getEndpointAuthorizationParameter(backendServiceName, "tenantid", true),
+                arm_client_id           : tasks.getEndpointAuthorizationParameter(backendServiceName, "serviceprincipalid", true),
+                arm_client_secret       : tasks.getEndpointAuthorizationParameter(backendServiceName, "serviceprincipalkey", true)
             }
 
             for(var config in backendConfig){
@@ -100,12 +100,12 @@ export class TerraformWithBackend extends TerraformCommandDecorator{
     private ensureBackend(backendConfig: AzureBackendConfig, location: string, sku: string){
         let shell = new CommandPipeline()
             .azLogin(new AzLogin(
-                backendConfig.tenant_id,
-                backendConfig.client_id,
-                backendConfig.client_secret
+                backendConfig.arm_tenant_id,
+                backendConfig.arm_client_id,
+                backendConfig.arm_client_secret
             ))
             .azAccountSet(new AzAccountSet(
-                backendConfig.subscription_id
+                backendConfig.arm_subscription_id
             ))
             .azGroupCreate(new AzGroupCreate(
                 backendConfig.resource_group_name,

--- a/TerraformCLI/src/tests/terraform-init/init-with-backend-azurerm-with-ensure-backend.env.ts
+++ b/TerraformCLI/src/tests/terraform-init/init-with-backend-azurerm-with-ensure-backend.env.ts
@@ -11,7 +11,7 @@ let servicePrincipalId: string = "servicePrincipal1";
 let servicePrincipalKey: string = "servicePrincipalKey123";
 
 let terraformCommand: string = 'init';
-let commandArgs: string = `-backend-config=storage_account_name=${backendStorageAccountName} -backend-config=container_name=${backendContainerName} -backend-config=key=${backendKey} -backend-config=resource_group_name=${backendResourceGroupName} -backend-config=subscription_id=${subscriptionId} -backend-config=tenant_id=${tenantId} -backend-config=client_id=${servicePrincipalId} -backend-config=client_secret=${servicePrincipalKey}`
+let commandArgs: string = `-backend-config=storage_account_name=${backendStorageAccountName} -backend-config=container_name=${backendContainerName} -backend-config=key=${backendKey} -backend-config=resource_group_name=${backendResourceGroupName} -backend-config=arm_subscription_id=${subscriptionId} -backend-config=arm_tenant_id=${tenantId} -backend-config=arm_client_id=${servicePrincipalId} -backend-config=arm_client_secret=${servicePrincipalKey}`
 let expectedCommand: string = `${terraformCommand} ${commandArgs}`
 
 export let env: any = {

--- a/TerraformCLI/src/tests/terraform-init/init-with-backend-azurerm-with-ensure-existing-backend.env.ts
+++ b/TerraformCLI/src/tests/terraform-init/init-with-backend-azurerm-with-ensure-existing-backend.env.ts
@@ -11,7 +11,7 @@ let servicePrincipalId: string = "servicePrincipal1";
 let servicePrincipalKey: string = "servicePrincipalKey123";
 
 let terraformCommand: string = 'init';
-let commandArgs: string = `-backend-config=storage_account_name=${backendStorageAccountName} -backend-config=container_name=${backendContainerName} -backend-config=key=${backendKey} -backend-config=resource_group_name=${backendResourceGroupName} -backend-config=subscription_id=${subscriptionId} -backend-config=tenant_id=${tenantId} -backend-config=client_id=${servicePrincipalId} -backend-config=client_secret=${servicePrincipalKey}`
+let commandArgs: string = `-backend-config=storage_account_name=${backendStorageAccountName} -backend-config=container_name=${backendContainerName} -backend-config=key=${backendKey} -backend-config=resource_group_name=${backendResourceGroupName} -backend-config=arm_subscription_id=${subscriptionId} -backend-config=arm_tenant_id=${tenantId} -backend-config=arm_client_id=${servicePrincipalId} -backend-config=arm_client_secret=${servicePrincipalKey}`
 let expectedCommand: string = `${terraformCommand} ${commandArgs}`
 
 export let env: any = {

--- a/TerraformCLI/src/tests/terraform-init/init-with-backend-azurerm.env.ts
+++ b/TerraformCLI/src/tests/terraform-init/init-with-backend-azurerm.env.ts
@@ -9,7 +9,7 @@ let servicePrincipalId: string = "servicePrincipal1";
 let servicePrincipalKey: string = "servicePrincipalKey123";
 
 let terraformCommand: string = 'init';
-let commandArgs: string = `-backend-config=storage_account_name=${backendStorageAccountName} -backend-config=container_name=${backendContainerName} -backend-config=key=${backendKey} -backend-config=resource_group_name=${backendResourceGroupName} -backend-config=subscription_id=${subscriptionId} -backend-config=tenant_id=${tenantId} -backend-config=client_id=${servicePrincipalId} -backend-config=client_secret=${servicePrincipalKey}`
+let commandArgs: string = `-backend-config=storage_account_name=${backendStorageAccountName} -backend-config=container_name=${backendContainerName} -backend-config=key=${backendKey} -backend-config=resource_group_name=${backendResourceGroupName} -backend-config=arm_subscription_id=${subscriptionId} -backend-config=arm_tenant_id=${tenantId} -backend-config=arm_client_id=${servicePrincipalId} -backend-config=arm_client_secret=${servicePrincipalKey}`
 let expectedCommand: string = `${terraformCommand} ${commandArgs}`
 
 export let env: any = {

--- a/overview.md
+++ b/overview.md
@@ -13,8 +13,17 @@ The Terraform CLI task supports executing the following commands
 - apply
 - destroy
 - show
-- refresh (NEW)
-- import (NEW)
+- refresh
+- import
+- **output (NEW)**
+
+## (NEW) Terraform Output to Pipeline Variables
+
+The TerraformCLI task supports running terraforms `output` command. When this is run, pipeline variables will be created from each output variable emitted from the `terraform output` command. Sensitive variables will be set as secret pipeline variables and their values will not be emitted to the pipeline logs.
+
+For example, an output variable named `some_string`  will set a pipeline variable named `TF_OUT_SOME_STRING`.
+
+This feature currently only supports primitive types `string`, `bool`, and `number`. Complex typed outputs such as `tuple` and `object` will be excluded from the translation.
 
 ## Compatible with Linux Build Agents
 
@@ -84,6 +93,6 @@ Sample expression
 and(succeeded(), eq(variables['TERRAFORM_PLAN_HAS_CHANGES'], 'true'))
 ```
 
-## Plan Destroy Detection
+## Terraform Plan Destroy Detection
 
 The task now has the ability to set a pipeline variable `TERRAFORM_PLAN_HAS_DESTROY_CHANGES` if a generated plan has destroy operations. To utilize this, run terraform plan and set the `-out=my-plan-file-path` to write the generated plan to a file. Then run `terraform show` and provide the path to the generated plan file in the `Target Plan or State File Path` input field. If show, detects a destroy operation within the plan file, then the pipeline variable `TERRAFORM_PLAN_HAS_DESTROY_CHANGES` will be set to true.

--- a/overview.md
+++ b/overview.md
@@ -13,17 +13,8 @@ The Terraform CLI task supports executing the following commands
 - apply
 - destroy
 - show
-- refresh
-- import
-- **output (NEW)**
-
-## (NEW) Terraform Output to Pipeline Variables
-
-The TerraformCLI task supports running terraforms `output` command. When this is run, pipeline variables will be created from each output variable emitted from the `terraform output` command. Sensitive variables will be set as secret pipeline variables and their values will not be emitted to the pipeline logs.
-
-For example, an output variable named `some_string`  will set a pipeline variable named `TF_OUT_SOME_STRING`.
-
-This feature currently only supports primitive types `string`, `bool`, and `number`. Complex typed outputs such as `tuple` and `object` will be excluded from the translation.
+- refresh (NEW)
+- import (NEW)
 
 ## Compatible with Linux Build Agents
 
@@ -93,6 +84,6 @@ Sample expression
 and(succeeded(), eq(variables['TERRAFORM_PLAN_HAS_CHANGES'], 'true'))
 ```
 
-## Terraform Plan Destroy Detection
+## Plan Destroy Detection
 
 The task now has the ability to set a pipeline variable `TERRAFORM_PLAN_HAS_DESTROY_CHANGES` if a generated plan has destroy operations. To utilize this, run terraform plan and set the `-out=my-plan-file-path` to write the generated plan to a file. Then run `terraform show` and provide the path to the generated plan file in the `Target Plan or State File Path` input field. If show, detects a destroy operation within the plan file, then the pipeline variable `TERRAFORM_PLAN_HAS_DESTROY_CHANGES` will be set to true.


### PR DESCRIPTION
This change rolls back the changes that were made for #136. This has caused pipeline to fail for those that are on versions of terraform 0.11 or older.