### PR TITLE
Added in support for `state` commands

### DIFF
--- a/TerraformCLI/README.md
+++ b/TerraformCLI/README.md
@@ -9,6 +9,7 @@ This tasks enables running terraform cli commands from Azure Devops Build and Re
 - import
 - refresh
 - force-unlock (under the alias `forceunlock`)
+- state
 
 Terraform is required to exist on the build agent prior to running this task. See TerraformInstaller task within this repository to install terraform.
 

--- a/TerraformCLI/src/index.ts
+++ b/TerraformCLI/src/index.ts
@@ -12,6 +12,7 @@ import { TerraformShowHandler } from "./terraform-show";
 import { TerraformRefreshHandler } from "./terraform-refresh";
 import { TerraformImportHandler } from "./terraform-import";
 import { TerraformForceUnlockHandler } from "./terraform-force-unlock";
+import { TerraformStateHandler } from "./terraform-state";
 import TaskAgent from "./task-agent";
 import { AzRunner } from "./az-runner";
 import { AzAccountSet, AzAccountSetResult, AzAccountSetHandler } from "./az-account-set";
@@ -80,6 +81,7 @@ container.bind<IHandleCommandString>(CommandInterfaces.IHandleCommandString).to(
 container.bind<IHandleCommandString>(CommandInterfaces.IHandleCommandString).to(TerraformImportHandler).whenTargetNamed("import");
 container.bind<IHandleCommandString>(CommandInterfaces.IHandleCommandString).to(TerraformOutputHandler).whenTargetNamed("output");
 container.bind<IHandleCommandString>(CommandInterfaces.IHandleCommandString).to(TerraformForceUnlockHandler).whenTargetNamed("forceunlock");
+container.bind<IHandleCommandString>(CommandInterfaces.IHandleCommandString).to(TerraformStateHandler).whenTargetNamed("state");
 
 // execute the terraform command
 let mediator = container.get<IMediator>(MediatorInterfaces.IMediator);

--- a/TerraformCLI/src/terraform-state.ts
+++ b/TerraformCLI/src/terraform-state.ts
@@ -1,0 +1,60 @@
+import tasks = require("azure-pipelines-task-lib/task");
+import { TerraformCommand, TerraformInterfaces, ITaskAgent, ILogger } from "./terraform";
+import { IHandleCommandString } from "./command-handler";
+import { injectable, inject } from "inversify";
+import { TerraformRunner } from "./terraform-runner";
+
+export class TerraformState extends TerraformCommand{
+    readonly secureVarsFile: string | undefined;
+    readonly environmentServiceName: string | undefined;
+
+    constructor(
+        name: string,
+        workingDirectory: string,
+        environmentServiceName: string | undefined,
+        secureVarsFile?: string,
+        options?: string) {
+        super(name, workingDirectory);
+        this.secureVarsFile = secureVarsFile;
+        this.environmentServiceName = environmentServiceName;
+    }
+}
+
+@injectable()
+export class TerraformStateHandler implements IHandleCommandString{
+    private readonly taskAgent: ITaskAgent;
+    private readonly log: ILogger;
+
+    constructor(
+        @inject(TerraformInterfaces.ITaskAgent) taskAgent: ITaskAgent,
+        @inject(TerraformInterfaces.ILogger) log: ILogger
+    ) {
+        this.taskAgent = taskAgent;
+        this.log = log;
+    }
+
+    public async execute(command: string): Promise<number> {
+        let stateCommand = new TerraformState(
+            command,
+            tasks.getInput("workingDirectory"),
+            tasks.getInput("environmentServiceName"),
+            tasks.getInput("secureVarsFile"),
+            tasks.getInput("commandOptions")
+        );
+
+        let loggedProps = {
+            "secureVarsFileDefined": apply.secureVarsFile !== undefined && apply.secureVarsFile !== '' && apply.secureVarsFile !== null,
+            "commandOptionsDefined": apply.options !== undefined && apply.options !== '' && apply.options !== null,
+            "environmentServiceNameDefined": apply.environmentServiceName !== undefined && apply.environmentServiceName !== '' && apply.environmentServiceName !== null,
+        }
+
+        return this.log.command(stateCommand, (command: TerraformState) => this.onExecute(command), loggedProps);
+    }
+
+    private async onExecute(command: TerraformState): Promise<number> {
+        return new TerraformRunner(command)
+            .withProvider(command.environmentServiceName)
+            .withSecureVarsFile(this.taskAgent, command.secureVarsFile)
+            .exec();
+    }
+}

--- a/TerraformCLI/src/terraform-state.ts
+++ b/TerraformCLI/src/terraform-state.ts
@@ -14,7 +14,7 @@ export class TerraformState extends TerraformCommand{
         environmentServiceName: string | undefined,
         secureVarsFile?: string,
         options?: string) {
-        super(name, workingDirectory);
+        super(name, workingDirectory, options);
         this.secureVarsFile = secureVarsFile;
         this.environmentServiceName = environmentServiceName;
     }
@@ -34,7 +34,7 @@ export class TerraformStateHandler implements IHandleCommandString{
     }
 
     public async execute(command: string): Promise<number> {
-        let stateCommand = new TerraformState(
+        let state = new TerraformState(
             command,
             tasks.getInput("workingDirectory"),
             tasks.getInput("environmentServiceName"),
@@ -43,12 +43,12 @@ export class TerraformStateHandler implements IHandleCommandString{
         );
 
         let loggedProps = {
-            "secureVarsFileDefined": apply.secureVarsFile !== undefined && apply.secureVarsFile !== '' && apply.secureVarsFile !== null,
-            "commandOptionsDefined": apply.options !== undefined && apply.options !== '' && apply.options !== null,
-            "environmentServiceNameDefined": apply.environmentServiceName !== undefined && apply.environmentServiceName !== '' && apply.environmentServiceName !== null,
+            "secureVarsFileDefined": state.secureVarsFile !== undefined && state.secureVarsFile !== '' && state.secureVarsFile !== null,
+            "commandOptionsDefined": state.options !== undefined && state.options !== '' && state.options !== null,
+            "environmentServiceNameDefined": state.environmentServiceName !== undefined && state.environmentServiceName !== '' && state.environmentServiceName !== null,
         }
 
-        return this.log.command(stateCommand, (command: TerraformState) => this.onExecute(command), loggedProps);
+        return this.log.command(state, (command: TerraformState) => this.onExecute(command), loggedProps);
     }
 
     private async onExecute(command: TerraformState): Promise<number> {

--- a/TerraformCLI/src/tests/terraform-state/default.env
+++ b/TerraformCLI/src/tests/terraform-state/default.env
@@ -1,0 +1,3 @@
+TF_VAR_region="eastus"
+TF_VAR_app-short-name="tffoo"
+TF_VAR_env-short-name="dev"

--- a/TerraformCLI/src/tests/terraform-state/default.vars
+++ b/TerraformCLI/src/tests/terraform-state/default.vars
@@ -1,0 +1,3 @@
+region="eastus"
+app-short-name="tffoo"
+env-short-name="dev"

--- a/TerraformCLI/src/tests/terraform-state/state_rm.env.ts
+++ b/TerraformCLI/src/tests/terraform-state/state_rm.env.ts
@@ -1,0 +1,29 @@
+const environmentServiceName = "dev";
+const subscriptionId: string = "sub1";
+const tenantId: string = "ten1";
+const servicePrincipalId: string = "servicePrincipal1";
+const servicePrincipalKey: string = "servicePrincipalKey123";
+
+const expectedEnv: { [key: string]: string } = {
+    'ARM_SUBSCRIPTION_ID': subscriptionId,
+    'ARM_TENANT_ID': tenantId,
+    'ARM_CLIENT_ID': servicePrincipalId,
+    'ARM_CLIENT_SECRET': servicePrincipalKey,
+}
+
+const terraformCommand: string = "state";
+const commandOptions: string = `rm 'module.foo'`;
+const expectedCommand: string = `${terraformCommand} ${commandOptions}`
+
+export let env: any = {
+    taskScenarioPath:           require.resolve('./state_rm'),
+    terraformCommand,
+    commandOptions,
+    expectedCommand,
+    environmentServiceName,
+    subscriptionId,
+    tenantId,
+    servicePrincipalId,
+    servicePrincipalKey,
+    expectedEnv
+}

--- a/TerraformCLI/src/tests/terraform-state/state_rm.ts
+++ b/TerraformCLI/src/tests/terraform-state/state_rm.ts
@@ -1,0 +1,13 @@
+import { TaskScenario } from './../scenarios';
+import { TerraformInputs } from '../scenarios-terraform';
+import '../scenarios-terraform';
+import { env } from './state_rm.env';
+
+new TaskScenario<TerraformInputs>()
+    .inputAzureRmServiceEndpoint(env.environmentServiceName, env.subscriptionId, env.tenantId, env.servicePrincipalId, env.servicePrincipalKey)
+    .inputTerraformCommand(env.terraformCommand, env.commandOptions)
+    .input({ environmentServiceName: env.environmentServiceName })
+    .inputApplicationInsightsInstrumentationKey()
+    .answerTerraformExists()    
+    .answerTerraformCommandIsSuccessful(env.commandOptions)
+    .run()

--- a/TerraformCLI/src/tests/terraform-state/state_spec.ts
+++ b/TerraformCLI/src/tests/terraform-state/state_spec.ts
@@ -1,0 +1,14 @@
+import { TestScenario } from '../assertions';
+import '../assertions-terraform';
+
+describe('terraform state', function(){
+    it('can use with options', function(){
+        let env = require('./state_rm.env').env
+        new TestScenario(env.taskScenarioPath)
+            .assertExecutedTerraformCommand(env.expectedCommand)
+            .assertExecutedTerraformVersion()
+            .assertExecutionSucceeded()
+            .run();
+
+    });
+});

--- a/TerraformCLI/task.json
+++ b/TerraformCLI/task.json
@@ -67,6 +67,7 @@
                 "import": "import",
                 "output": "output",
                 "forceunlock": "force-unlock"
+                "state": "state"
             },
             "properties": {
                 "EditableOptions": "False"

--- a/TerraformCLI/task.json
+++ b/TerraformCLI/task.json
@@ -66,7 +66,7 @@
                 "refresh": "refresh",
                 "import": "import",
                 "output": "output",
-                "forceunlock": "force-unlock"
+                "forceunlock": "force-unlock",
                 "state": "state"
             },
             "properties": {


### PR DESCRIPTION
Simple exposure of all `state` commands such as `state rm`.

There is no safety checking and all commands must provide their own options.