### PR TITLE
fix publish condition not passing for tags

### DIFF
--- a/pipelines/publish/publish.yml
+++ b/pipelines/publish/publish.yml
@@ -3,6 +3,6 @@ stages:
   dependsOn: test
   variables:
     - group: env_prod
-  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/tags/*'))
+  condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/'))
   jobs:
   - template: publish_marketplace.yml


### PR DESCRIPTION
asterisk wildcard does not work with the `eq()` function. Use startsWith instead.