### PR TITLE
Re-enabled secureVarFile for force-unlock

### DIFF
--- a/tasks/terraform-cli/src/commands/tf-force-unlock.ts
+++ b/tasks/terraform-cli/src/commands/tf-force-unlock.ts
@@ -25,6 +25,7 @@ export class TerraformForceUnlock implements ICommand {
         const provider = this.getProvider(ctx);
         const options = await new RunWithTerraform(ctx, undefined, "force-unlock")            
             .withProvider(ctx, provider)
+            .withSecureVarFile(this.taskAgent, ctx.secureVarsFileId, ctx.secureVarsFileName)
             .withForce()
             .withLockId(ctx.lockId)
             .build();

--- a/tasks/terraform-cli/src/commands/tf-force-unlock.ts
+++ b/tasks/terraform-cli/src/commands/tf-force-unlock.ts
@@ -1,13 +1,14 @@
-import { command } from "azure-pipelines-task-lib";
 import { CommandResponse, ICommand } from ".";
 import { ITaskContext } from "../context";
 import { ITerraformProvider } from "../providers";
 import AzureRMProvider from "../providers/azurerm";
 import { IRunner } from "../runners";
 import { RunWithTerraform } from "../runners/builders";
+import { ITaskAgent } from "../task-agent";
 
 export class TerraformForceUnlock implements ICommand {
     constructor(
+        private readonly taskAgent: ITaskAgent,
         private readonly runner: IRunner
         ) {
     }

--- a/tasks/terraform-cli/src/task.ts
+++ b/tasks/terraform-cli/src/task.ts
@@ -99,7 +99,7 @@ export class Task {
     }
 
     forceUnlock(): commands.ICommand {
-        return new commands.ForceUnlockCommandHandler(this.runner);
+        return new commands.ForceUnlockCommandHandler(this.taskAgent, this.runner);
     }
     
     show(): commands.ICommand {

--- a/tasks/terraform-cli/src/tests/features/terraform-force-unlock.feature
+++ b/tasks/terraform-cli/src/tests/features/terraform-force-unlock.feature
@@ -21,3 +21,27 @@ Feature: terraform force-unlock
             | ARM_CLIENT_SECRET   | servicePrincipalKey123 |
         And the terraform cli task is successful
         And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
+
+    Scenario: force-unlock with secure env file
+        Given terraform exists
+        And terraform command is "forceunlock"
+        And azurerm service connection "dev" exists as
+            | scheme         | ServicePrincipal       |
+            | subscriptionId | sub1                   |
+            | tenantId       | ten1                   |
+            | clientId       | servicePrincipal1      |
+            | clientSecret   | servicePrincipalKey123 |
+        And force-unlock is run with lock id "3ea12870-968e-b9b9-cf3b-f4c3fbe36684"        
+        And secure file specified with id "6b4ef608-ca4c-4185-92fb-0554b8a2ec72" and name "./src/tests/default.env"
+        And running command "terraform force-unlock -force 3ea12870-968e-b9b9-cf3b-f4c3fbe36684" returns successful result
+        When the terraform cli task is run
+        Then the terraform cli task executed command "terraform force-unlock -force 3ea12870-968e-b9b9-cf3b-f4c3fbe36684" with the following environment variables
+            | ARM_SUBSCRIPTION_ID | sub1                   |
+            | ARM_TENANT_ID       | ten1                   |
+            | ARM_CLIENT_ID       | servicePrincipal1      |
+            | ARM_CLIENT_SECRET   | servicePrincipalKey123 |
+            | TF_VAR_app-short-name | tffoo  |
+            | TF_VAR_region         | eastus |
+            | TF_VAR_env-short-name | dev    |
+        And the terraform cli task is successful
+        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"


### PR DESCRIPTION
`force-unlock` command had a defect introduced where the secure-var-file is not used. This PR will re-enable it.