### PR TITLE
Allow local-exec provisioner to execute az-cli commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,6 @@ dist
 
 # tfx runtime files
 .taskkey
+
+
+.terraform.lock.hcl

--- a/overview.md
+++ b/overview.md
@@ -66,6 +66,29 @@ When executing commands that interact with Azure such as `plan`, `apply`, and `d
         environmentServiceName: 'My Azure Service Connection'
 ```
 
+### **Execute Azure CLI From Local-Exec Provisioner (NEW)**
+
+When an azure service connection is provided, the terraform cli task will run `az login` using the service connection credentials. This is intended to enable templates to execute az cli commands from a `local-exec` provisioner.
+
+This should allow the following template configuation to be run using this task
+
+```terraform
+resource "azurerm_storage_account" "st_core" {
+  name                      = "my-storage-account"
+  location                  = "eastus"
+  resource_group_name       = azurerm_resource_group.rg_core.name
+  account_kind              = "StorageV2"
+  account_tier              = "Standard"
+  account_replication_type  = "LRS"
+  
+
+  # can now be run by the terraform cli task from azure pipelines
+  provisioner "local-exec" {
+          command = "az storage blob service-properties update --account-name ${azurerm_storage_account.st_core.name} --static-website --index-document index.html --404-document index.html"
+  }
+}
+```
+
 ## Remote, Local and Self-configured Backend State Support
 
 The task currently supports the following backend configurations

--- a/overview.md
+++ b/overview.md
@@ -117,7 +117,7 @@ There are multiple methods to provide secrets within the vars provided to terraf
         commandOptions: '-var secret=$(mySecretPipelineVar)'
 ```
 
-### Secure Env Files (NEW)
+### Secure Env Files
 
 If the Secure Variables file name is `*.env`, it is referred as `.env` file. This task loads environment variables from the `.env` file.
 

--- a/pipelines/test/local_exec_az_cli.yml
+++ b/pipelines/test/local_exec_az_cli.yml
@@ -1,0 +1,51 @@
+jobs:
+- job: local_exec_az_cli
+  variables: 
+    test_templates_dir: $(terraform_templates_dir)/local-exec-az-cli
+  steps:
+    - task: DownloadPipelineArtifact@2
+      displayName: download terraform templates
+      inputs: 
+        artifact: terraform_templates
+        path: $(terraform_extension_dir)
+    - task: TerraformCLI@0
+      displayName: 'terraform init'
+      inputs:
+        command: init
+        workingDirectory: $(test_templates_dir)
+        backendType: azurerm
+        backendServiceArm: 'env_test'
+        ensureBackend: true
+        backendAzureRmResourceGroupName: '$(backend_arm_resource_group)'
+        backendAzureRmResourceGroupLocation: '$(backend_arm_location)'
+        backendAzureRmStorageAccountName: '$(backend_arm_storage_name)'
+        backendAzureRmStorageAccountSku: '$(backend_arm_storage_sku)'
+        backendAzureRmContainerName: '$(backend_arm_storage_container)'
+        backendAzureRmKey: local_exec_az_cli.tfstate
+    - task: TerraformCLI@0
+      displayName: 'terraform validate'
+      inputs:
+        workingDirectory: $(test_templates_dir)
+        secureVarsFile: 85f60b61-3430-4e92-83be-ea5b16eafaaf
+    - task: TerraformCLI@0
+      displayName: 'terraform plan'
+      inputs:
+        command: plan
+        workingDirectory: $(test_templates_dir)
+        environmentServiceName: 'env_test'
+        secureVarsFile: 85f60b61-3430-4e92-83be-ea5b16eafaaf
+        commandOptions: '-out=$(System.DefaultWorkingDirectory)/terraform.tfplan'
+    - task: TerraformCLI@0
+      displayName: 'terraform apply'
+      inputs:
+        command: apply
+        workingDirectory: $(test_templates_dir)
+        environmentServiceName: 'env_test'
+        commandOptions: '$(System.DefaultWorkingDirectory)/terraform.tfplan'
+    - task: TerraformCLI@0
+      displayName: 'terraform destroy'
+      inputs:
+        command: destroy
+        workingDirectory: $(test_templates_dir)
+        environmentServiceName: 'env_test'
+        secureVarsFile: 85f60b61-3430-4e92-83be-ea5b16eafaaf

--- a/pipelines/test/test.yml
+++ b/pipelines/test/test.yml
@@ -1,5 +1,5 @@
 parameters:
-  scenarios: ["test_1.yml"]
+  scenarios: ["test_1.yml", "local_exec_az_cli.yml"]
 
 stages:
 - stage: test

--- a/tasks/terraform-cli/src/commands/az-login.ts
+++ b/tasks/terraform-cli/src/commands/az-login.ts
@@ -10,12 +10,23 @@ export class AzLogin implements ICommand {
 
     async exec(ctx: ITaskContext): Promise<CommandResponse>{
         const options = await new RunWithAzCli("login").build();
-        options.addArgs(
-            "--service-principal", 
-            "-t", ctx.backendServiceArmTenantId || ctx.environmentServiceArmTenantId,
-            "-u", ctx.backendServiceArmClientId || ctx.environmentServiceArmClientId,
-            "-p", ctx.backendServiceArmClientSecret || ctx.environmentServiceArmClientSecret
-        );
+        if(ctx.backendServiceArm){
+            options.addArgs(
+                "--service-principal", 
+                "-t", ctx.backendServiceArmTenantId,
+                "-u", ctx.backendServiceArmClientId,
+                "-p", ctx.backendServiceArmClientSecret
+            );
+        }
+        else{
+            options.addArgs(
+                "--service-principal", 
+                "-t", ctx.environmentServiceArmTenantId,
+                "-u", ctx.environmentServiceArmClientId,
+                "-p", ctx.environmentServiceArmClientSecret
+            );
+        }
+        
         const result = await this.runner.exec(options);
         return result.toCommandResponse();
     }

--- a/tasks/terraform-cli/src/commands/az-login.ts
+++ b/tasks/terraform-cli/src/commands/az-login.ts
@@ -12,9 +12,9 @@ export class AzLogin implements ICommand {
         const options = await new RunWithAzCli("login").build();
         options.addArgs(
             "--service-principal", 
-            "-t", ctx.backendServiceArmTenantId,
-            "-u", ctx.backendServiceArmClientId,
-            "-p", ctx.backendServiceArmClientSecret
+            "-t", ctx.backendServiceArmTenantId || ctx.environmentServiceArmTenantId,
+            "-u", ctx.backendServiceArmClientId || ctx.environmentServiceArmClientId,
+            "-p", ctx.backendServiceArmClientSecret || ctx.environmentServiceArmClientSecret
         );
         const result = await this.runner.exec(options);
         return result.toCommandResponse();

--- a/tasks/terraform-cli/src/commands/tf-apply.ts
+++ b/tasks/terraform-cli/src/commands/tf-apply.ts
@@ -1,4 +1,4 @@
-import { CommandResponse, ICommand } from ".";
+import { CommandPipeline, CommandResponse, ICommand } from ".";
 import { ITaskContext } from "../context";
 import { ITerraformProvider } from "../providers";
 import AzureRMProvider from "../providers/azurerm";
@@ -17,19 +17,20 @@ export class TerraformApply implements ICommand {
     private getProvider(ctx: ITaskContext): ITerraformProvider | undefined {
         let provider: ITerraformProvider | undefined;
         if(ctx.environmentServiceName){
-            provider = new AzureRMProvider();
+            provider = new AzureRMProvider(this.runner);
         }
         return provider;
     }
 
     async exec(ctx: ITaskContext): Promise<CommandResponse> {
-        const provider = this.getProvider(ctx);
+        const provider = this.getProvider(ctx);        
         const options = await new RunWithTerraform(ctx)            
             .withSecureVarFile(this.taskAgent, ctx.secureVarsFileId, ctx.secureVarsFileName)    
             .withAutoApprove()
             .withProvider(ctx, provider)
             .withCommandOptions(ctx.commandOptions)
             .build();
+        
         const result = await this.runner.exec(options);
 
         return result.toCommandResponse();

--- a/tasks/terraform-cli/src/commands/tf-destroy.ts
+++ b/tasks/terraform-cli/src/commands/tf-destroy.ts
@@ -17,7 +17,7 @@ export class TerraformDestroy implements ICommand {
     private getProvider(ctx: ITaskContext): ITerraformProvider | undefined {
         let provider: ITerraformProvider | undefined;
         if(ctx.environmentServiceName){
-            provider = new AzureRMProvider();
+            provider = new AzureRMProvider(this.runner);
         }
         return provider;
     }

--- a/tasks/terraform-cli/src/commands/tf-force-unlock.ts
+++ b/tasks/terraform-cli/src/commands/tf-force-unlock.ts
@@ -15,7 +15,7 @@ export class TerraformForceUnlock implements ICommand {
     private getProvider(ctx: ITaskContext): ITerraformProvider | undefined {
         let provider: ITerraformProvider | undefined;
         if(ctx.environmentServiceName){
-            provider = new AzureRMProvider();
+            provider = new AzureRMProvider(this.runner);
         }
         return provider;
     }

--- a/tasks/terraform-cli/src/commands/tf-import.ts
+++ b/tasks/terraform-cli/src/commands/tf-import.ts
@@ -17,7 +17,7 @@ export class TerraformImport implements ICommand {
     private getProvider(ctx: ITaskContext): ITerraformProvider | undefined {
         let provider: ITerraformProvider | undefined;
         if(ctx.environmentServiceName){
-            provider = new AzureRMProvider();
+            provider = new AzureRMProvider(this.runner);
         }
         return provider;
     }

--- a/tasks/terraform-cli/src/commands/tf-plan.ts
+++ b/tasks/terraform-cli/src/commands/tf-plan.ts
@@ -17,7 +17,7 @@ export class TerraformPlan implements ICommand {
     private getProvider(ctx: ITaskContext): ITerraformProvider | undefined {
         let provider: ITerraformProvider | undefined;
         if(ctx.environmentServiceName){
-            provider = new AzureRMProvider();
+            provider = new AzureRMProvider(this.runner);
         }
         return provider;
     }

--- a/tasks/terraform-cli/src/commands/tf-refresh.ts
+++ b/tasks/terraform-cli/src/commands/tf-refresh.ts
@@ -17,7 +17,7 @@ export class TerraformRefresh implements ICommand {
     private getProvider(ctx: ITaskContext): ITerraformProvider | undefined {
         let provider: ITerraformProvider | undefined;
         if(ctx.environmentServiceName){
-            provider = new AzureRMProvider();
+            provider = new AzureRMProvider(this.runner);
         }
         return provider;
     }

--- a/tasks/terraform-cli/src/context/azdo-task-context.ts
+++ b/tasks/terraform-cli/src/context/azdo-task-context.ts
@@ -44,7 +44,7 @@ export default class AzdoTaskContext implements ITaskContext {
         return this.getBoolInput("ensureBackend");
     }
     get backendServiceArm() {
-        return this.getInput("backendServiceArm", true);
+        return this.getInput("backendServiceArm");
     }
     get backendAzureRmResourceGroupName() {
         return this.getInput("backendAzureRmResourceGroupName", true);

--- a/tasks/terraform-cli/src/providers/azurerm.ts
+++ b/tasks/terraform-cli/src/providers/azurerm.ts
@@ -35,6 +35,7 @@ export default class AzureRMProvider implements ITerraformProvider {
 
         //run az login so provisioners needing az cli can be run.
         await new CommandPipeline(this.runner)
-            .azLogin();
+            .azLogin()
+            .exec(ctx);
     }
 }

--- a/tasks/terraform-cli/src/providers/azurerm.ts
+++ b/tasks/terraform-cli/src/providers/azurerm.ts
@@ -1,5 +1,7 @@
 import { ITerraformProvider } from ".";
+import { CommandPipeline } from "../commands";
 import { ITaskContext } from "../context";
+import { IRunner } from "../runners";
 
 interface AzureRMProviderConfiguration{
     scheme: string;
@@ -10,7 +12,8 @@ interface AzureRMProviderConfiguration{
 }
 
 export default class AzureRMProvider implements ITerraformProvider {
-    constructor(){
+    constructor(
+        private readonly runner: IRunner){
     }
 
     async init(ctx: ITaskContext): Promise<void> {
@@ -29,5 +32,9 @@ export default class AzureRMProvider implements ITerraformProvider {
         process.env['ARM_TENANT_ID']        = config.tenantId;
         process.env['ARM_CLIENT_ID']        = config.clientId;
         process.env['ARM_CLIENT_SECRET']    = config.clientSecret;
+
+        //run az login so provisioners needing az cli can be run.
+        await new CommandPipeline(this.runner)
+            .azLogin();
     }
 }

--- a/tasks/terraform-cli/src/tests/features/terraform-apply.feature
+++ b/tasks/terraform-cli/src/tests/features/terraform-apply.feature
@@ -21,12 +21,24 @@ Feature: terraform apply
             | clientId       | servicePrincipal1      |
             | clientSecret   | servicePrincipalKey123 |
         And running command "terraform apply -auto-approve" returns successful result
+        And running command "az login" with the following options returns successful result
+            | option                    |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         When the terraform cli task is run
         Then the terraform cli task executed command "terraform apply -auto-approve" with the following environment variables
             | ARM_SUBSCRIPTION_ID | sub1                   |
             | ARM_TENANT_ID       | ten1                   |
             | ARM_CLIENT_ID       | servicePrincipal1      |
             | ARM_CLIENT_SECRET   | servicePrincipalKey123 |
+        And azure login is executed with the following options
+            | option                |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And the terraform cli task is successful
         And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
 

--- a/tasks/terraform-cli/src/tests/features/terraform-apply.feature
+++ b/tasks/terraform-cli/src/tests/features/terraform-apply.feature
@@ -21,6 +21,7 @@ Feature: terraform apply
             | clientId       | servicePrincipal1      |
             | clientSecret   | servicePrincipalKey123 |
         And running command "terraform apply -auto-approve" returns successful result
+        And azure cli exists
         And running command "az login" with the following options returns successful result
             | option                    |
             | --service-principal       |

--- a/tasks/terraform-cli/src/tests/features/terraform-apply.feature
+++ b/tasks/terraform-cli/src/tests/features/terraform-apply.feature
@@ -53,12 +53,25 @@ Feature: terraform apply
             | clientId       | servicePrincipal1      |
             | clientSecret   | servicePrincipalKey123 |
         And running command "terraform apply -auto-approve -input=true -lock=false -no-color" returns successful result
+        And azure cli exists
+        And running command "az login" with the following options returns successful result
+            | option                    |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         When the terraform cli task is run        
         Then the terraform cli task executed command "terraform apply -auto-approve -input=true -lock=false -no-color" with the following environment variables
             | ARM_SUBSCRIPTION_ID | sub1                   |
             | ARM_TENANT_ID       | ten1                   |
             | ARM_CLIENT_ID       | servicePrincipal1      |
             | ARM_CLIENT_SECRET   | servicePrincipalKey123 |
+        And azure login is executed with the following options
+            | option                |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And the terraform cli task is successful
         And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
 
@@ -71,6 +84,13 @@ Feature: terraform apply
             | tenantId       | ten1                   |
             | clientId       | servicePrincipal1      |
             | clientSecret   | servicePrincipalKey123 |
+        And azure cli exists
+        And running command "az login" with the following options returns successful result
+            | option                    |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And secure file specified with id "6b4ef608-ca4c-4185-92fb-0554b8a2ec72" and name "./src/tests/default.vars"
         And running command "terraform apply -var-file=./src/tests/default.vars -auto-approve" returns successful result
         When the terraform cli task is run
@@ -79,6 +99,12 @@ Feature: terraform apply
             | ARM_TENANT_ID       | ten1                   |
             | ARM_CLIENT_ID       | servicePrincipal1      |
             | ARM_CLIENT_SECRET   | servicePrincipalKey123 |
+        And azure login is executed with the following options
+            | option                |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And the terraform cli task is successful
         And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
 
@@ -91,6 +117,13 @@ Feature: terraform apply
             | tenantId       | ten1                   |
             | clientId       | servicePrincipal1      |
             | clientSecret   | servicePrincipalKey123 |
+        And azure cli exists
+        And running command "az login" with the following options returns successful result
+            | option                    |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And secure file specified with id "6b4ef608-ca4c-4185-92fb-0554b8a2ec72" and name "./src/tests/default.env"
         And running command "terraform apply -auto-approve" returns successful result
         When the terraform cli task is run
@@ -102,6 +135,12 @@ Feature: terraform apply
             | TF_VAR_app-short-name | tffoo  |
             | TF_VAR_region         | eastus |
             | TF_VAR_env-short-name | dev    |
+        And azure login is executed with the following options
+            | option                |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And the terraform cli task is successful
         And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
 
@@ -114,6 +153,13 @@ Feature: terraform apply
             | tenantId       | ten1                   |
             | clientId       | servicePrincipal1      |
             | clientSecret   | servicePrincipalKey123 |
+        And azure cli exists
+        And running command "az login" with the following options returns successful result
+            | option                    |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And running command "terraform apply" returns successful result
         When the terraform cli task is run
         Then the terraform cli task fails with message "Terraform only supports service principal authorization for azure"

--- a/tasks/terraform-cli/src/tests/features/terraform-destroy.feature
+++ b/tasks/terraform-cli/src/tests/features/terraform-destroy.feature
@@ -66,6 +66,12 @@ Feature: terraform destroy
             | ARM_TENANT_ID       | ten1                   |
             | ARM_CLIENT_ID       | servicePrincipal1      |
             | ARM_CLIENT_SECRET   | servicePrincipalKey123 |
+        And azure login is executed with the following options
+            | option                |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And the terraform cli task is successful
         And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
 
@@ -93,6 +99,12 @@ Feature: terraform destroy
             | ARM_TENANT_ID       | ten1                   |
             | ARM_CLIENT_ID       | servicePrincipal1      |
             | ARM_CLIENT_SECRET   | servicePrincipalKey123 |
+        And azure login is executed with the following options
+            | option                |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And the terraform cli task is successful
         And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
 
@@ -123,6 +135,12 @@ Feature: terraform destroy
             | TF_VAR_app-short-name | tffoo                  |
             | TF_VAR_region         | eastus                 |
             | TF_VAR_env-short-name | dev                    |
+        And azure login is executed with the following options
+            | option                |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And the terraform cli task is successful
         And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
 

--- a/tasks/terraform-cli/src/tests/features/terraform-destroy.feature
+++ b/tasks/terraform-cli/src/tests/features/terraform-destroy.feature
@@ -21,12 +21,25 @@ Feature: terraform destroy
             | clientId       | servicePrincipal1      |
             | clientSecret   | servicePrincipalKey123 |
         And running command "terraform destroy -auto-approve" returns successful result
+        And azure cli exists
+        And running command "az login" with the following options returns successful result
+            | option                    |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         When the terraform cli task is run
         Then the terraform cli task executed command "terraform destroy -auto-approve" with the following environment variables
             | ARM_SUBSCRIPTION_ID | sub1                   |
             | ARM_TENANT_ID       | ten1                   |
             | ARM_CLIENT_ID       | servicePrincipal1      |
             | ARM_CLIENT_SECRET   | servicePrincipalKey123 |
+        And azure login is executed with the following options
+            | option                |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And the terraform cli task is successful
         And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
 

--- a/tasks/terraform-cli/src/tests/features/terraform-destroy.feature
+++ b/tasks/terraform-cli/src/tests/features/terraform-destroy.feature
@@ -43,7 +43,7 @@ Feature: terraform destroy
         And the terraform cli task is successful
         And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
 
-    Scenario: destroy with azurerm and command options
+    Scenario: destroy with foo and command options
         Given terraform exists
         And terraform command is "destroy" with options "-input=true -lock=false -no-color"
         And azurerm service connection "dev" exists as
@@ -52,6 +52,13 @@ Feature: terraform destroy
             | tenantId       | ten1                   |
             | clientId       | servicePrincipal1      |
             | clientSecret   | servicePrincipalKey123 |
+        And azure cli exists
+        And running command "az login" with the following options returns successful result
+            | option                    |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And running command "terraform destroy -auto-approve -input=true -lock=false -no-color" returns successful result
         When the terraform cli task is run
         Then the terraform cli task executed command "terraform destroy -auto-approve -input=true -lock=false -no-color" with the following environment variables
@@ -71,6 +78,13 @@ Feature: terraform destroy
             | tenantId       | ten1                   |
             | clientId       | servicePrincipal1      |
             | clientSecret   | servicePrincipalKey123 |
+        And azure cli exists
+        And running command "az login" with the following options returns successful result
+            | option                    |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And secure file specified with id "6b4ef608-ca4c-4185-92fb-0554b8a2ec72" and name "./src/tests/default.vars"
         And running command "terraform destroy -var-file=./src/tests/default.vars -auto-approve" returns successful result
         When the terraform cli task is run
@@ -91,6 +105,13 @@ Feature: terraform destroy
             | tenantId       | ten1                   |
             | clientId       | servicePrincipal1      |
             | clientSecret   | servicePrincipalKey123 |
+        And azure cli exists
+        And running command "az login" with the following options returns successful result
+            | option                    |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And secure file specified with id "6b4ef608-ca4c-4185-92fb-0554b8a2ec72" and name "./src/tests/default.env"
         And running command "terraform destroy -auto-approve" returns successful result
         When the terraform cli task is run

--- a/tasks/terraform-cli/src/tests/features/terraform-force-unlock.feature
+++ b/tasks/terraform-cli/src/tests/features/terraform-force-unlock.feature
@@ -11,6 +11,13 @@ Feature: terraform force-unlock
             | tenantId       | ten1                   |
             | clientId       | servicePrincipal1      |
             | clientSecret   | servicePrincipalKey123 |
+        And azure cli exists
+        And running command "az login" with the following options returns successful result
+            | option                    |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And force-unlock is run with lock id "3ea12870-968e-b9b9-cf3b-f4c3fbe36684"
         And running command "terraform force-unlock -force 3ea12870-968e-b9b9-cf3b-f4c3fbe36684" returns successful result
         When the terraform cli task is run
@@ -19,5 +26,11 @@ Feature: terraform force-unlock
             | ARM_TENANT_ID       | ten1                   |
             | ARM_CLIENT_ID       | servicePrincipal1      |
             | ARM_CLIENT_SECRET   | servicePrincipalKey123 |
+        And azure login is executed with the following options
+            | option                |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And the terraform cli task is successful
         And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"

--- a/tasks/terraform-cli/src/tests/features/terraform-force-unlock.feature
+++ b/tasks/terraform-cli/src/tests/features/terraform-force-unlock.feature
@@ -44,6 +44,13 @@ Feature: terraform force-unlock
             | tenantId       | ten1                   |
             | clientId       | servicePrincipal1      |
             | clientSecret   | servicePrincipalKey123 |
+        And azure cli exists
+        And running command "az login" with the following options returns successful result
+            | option                    |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And force-unlock is run with lock id "3ea12870-968e-b9b9-cf3b-f4c3fbe36684"        
         And secure file specified with id "6b4ef608-ca4c-4185-92fb-0554b8a2ec72" and name "./src/tests/default.env"
         And running command "terraform force-unlock -force 3ea12870-968e-b9b9-cf3b-f4c3fbe36684" returns successful result
@@ -56,5 +63,11 @@ Feature: terraform force-unlock
             | TF_VAR_app-short-name | tffoo  |
             | TF_VAR_region         | eastus |
             | TF_VAR_env-short-name | dev    |
+        And azure login is executed with the following options
+            | option                |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And the terraform cli task is successful
         And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"

--- a/tasks/terraform-cli/src/tests/features/terraform-import.feature
+++ b/tasks/terraform-cli/src/tests/features/terraform-import.feature
@@ -1,3 +1,4 @@
+@tf-import
 Feature: terraform import
 
     terraform import [options] [resource address] [resource id]
@@ -21,6 +22,13 @@ Feature: terraform import
             | tenantId       | ten1                   |
             | clientId       | servicePrincipal1      |
             | clientSecret   | servicePrincipalKey123 |
+        And azure cli exists
+        And running command "az login" with the following options returns successful result
+            | option                    |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And resource target provided with address "azurerm_resource_group.rg" and id "/subscriptions/sub1/resourceGroups/rg-tffoo-dev-eastus"
         And running command "terraform import azurerm_resource_group.rg /subscriptions/sub1/resourceGroups/rg-tffoo-dev-eastus" returns successful result
         When the terraform cli task is run
@@ -29,6 +37,12 @@ Feature: terraform import
             | ARM_TENANT_ID       | ten1                   |
             | ARM_CLIENT_ID       | servicePrincipal1      |
             | ARM_CLIENT_SECRET   | servicePrincipalKey123 |
+        And azure login is executed with the following options
+            | option                |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And the terraform cli task is successful
         And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
     
@@ -41,6 +55,13 @@ Feature: terraform import
             | tenantId       | ten1                   |
             | clientId       | servicePrincipal1      |
             | clientSecret   | servicePrincipalKey123 |
+        And azure cli exists
+        And running command "az login" with the following options returns successful result
+            | option                    |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And resource target provided with address "azurerm_resource_group.rg" and id "/subscriptions/sub1/resourceGroups/rg-tffoo-dev-eastus"
         And running command "terraform import -input=true -lock=false -no-color azurerm_resource_group.rg /subscriptions/sub1/resourceGroups/rg-tffoo-dev-eastus" returns successful result
         When the terraform cli task is run        
@@ -49,6 +70,12 @@ Feature: terraform import
             | ARM_TENANT_ID       | ten1                   |
             | ARM_CLIENT_ID       | servicePrincipal1      |
             | ARM_CLIENT_SECRET   | servicePrincipalKey123 |
+        And azure login is executed with the following options
+            | option                |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And the terraform cli task is successful
         And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
 
@@ -61,6 +88,13 @@ Feature: terraform import
             | tenantId       | ten1                   |
             | clientId       | servicePrincipal1      |
             | clientSecret   | servicePrincipalKey123 |
+        And azure cli exists
+        And running command "az login" with the following options returns successful result
+            | option                    |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And secure file specified with id "6b4ef608-ca4c-4185-92fb-0554b8a2ec72" and name "./src/tests/default.vars"
         And resource target provided with address "azurerm_resource_group.rg" and id "/subscriptions/sub1/resourceGroups/rg-tffoo-dev-eastus"
         And running command "terraform import -var-file=./src/tests/default.vars azurerm_resource_group.rg /subscriptions/sub1/resourceGroups/rg-tffoo-dev-eastus" returns successful result
@@ -70,6 +104,12 @@ Feature: terraform import
             | ARM_TENANT_ID       | ten1                   |
             | ARM_CLIENT_ID       | servicePrincipal1      |
             | ARM_CLIENT_SECRET   | servicePrincipalKey123 |
+        And azure login is executed with the following options
+            | option                |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And the terraform cli task is successful
         And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
 
@@ -82,6 +122,13 @@ Feature: terraform import
             | tenantId       | ten1                   |
             | clientId       | servicePrincipal1      |
             | clientSecret   | servicePrincipalKey123 |
+        And azure cli exists
+        And running command "az login" with the following options returns successful result
+            | option                    |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And secure file specified with id "6b4ef608-ca4c-4185-92fb-0554b8a2ec72" and name "./src/tests/default.env"
         And resource target provided with address "azurerm_resource_group.rg" and id "/subscriptions/sub1/resourceGroups/rg-tffoo-dev-eastus"
         And running command "terraform import azurerm_resource_group.rg /subscriptions/sub1/resourceGroups/rg-tffoo-dev-eastus" returns successful result
@@ -94,5 +141,11 @@ Feature: terraform import
             | TF_VAR_app-short-name | tffoo  |
             | TF_VAR_region         | eastus |
             | TF_VAR_env-short-name | dev    |
+        And azure login is executed with the following options
+            | option                |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And the terraform cli task is successful
         And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"

--- a/tasks/terraform-cli/src/tests/features/terraform-plan.feature
+++ b/tasks/terraform-cli/src/tests/features/terraform-plan.feature
@@ -84,6 +84,13 @@ Feature: terraform plan
             | tenantId       | ten1                   |
             | clientId       | servicePrincipal1      |
             | clientSecret   | servicePrincipalKey123 |
+        And azure cli exists
+        And running command "az login" with the following options returns successful result
+            | option                    |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And running command "terraform plan -var-file=./default.vars" returns successful result
         When the terraform cli task is run        
         Then the terraform cli task executed command "terraform plan -var-file=./default.vars" with the following environment variables
@@ -91,6 +98,12 @@ Feature: terraform plan
             | ARM_TENANT_ID       | ten1                   |
             | ARM_CLIENT_ID       | servicePrincipal1      |
             | ARM_CLIENT_SECRET   | servicePrincipalKey123 |
+        And azure login is executed with the following options
+            | option                |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And the terraform cli task is successful
         And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
 

--- a/tasks/terraform-cli/src/tests/features/terraform-plan.feature
+++ b/tasks/terraform-cli/src/tests/features/terraform-plan.feature
@@ -20,6 +20,13 @@ Feature: terraform plan
             | tenantId       | ten1                   |
             | clientId       | servicePrincipal1      |
             | clientSecret   | servicePrincipalKey123 |
+        And azure cli exists
+        And running command "az login" with the following options returns successful result
+            | option                    |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And running command "terraform plan" returns successful result
         When the terraform cli task is run
         Then the terraform cli task executed command "terraform plan" with the following environment variables
@@ -27,6 +34,12 @@ Feature: terraform plan
             | ARM_TENANT_ID       | ten1                   |
             | ARM_CLIENT_ID       | servicePrincipal1      |
             | ARM_CLIENT_SECRET   | servicePrincipalKey123 |
+        And azure login is executed with the following options
+            | option                |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And the terraform cli task is successful
         And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
 
@@ -39,6 +52,13 @@ Feature: terraform plan
             | tenantId       | ten1                   |
             | clientId       | servicePrincipal1      |
             | clientSecret   | servicePrincipalKey123 |
+        And azure cli exists
+        And running command "az login" with the following options returns successful result
+            | option                    |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And running command "terraform plan -input=true -lock=false -no-color" returns successful result
         When the terraform cli task is run        
         Then the terraform cli task executed command "terraform plan -input=true -lock=false -no-color" with the following environment variables
@@ -46,6 +66,12 @@ Feature: terraform plan
             | ARM_TENANT_ID       | ten1                   |
             | ARM_CLIENT_ID       | servicePrincipal1      |
             | ARM_CLIENT_SECRET   | servicePrincipalKey123 |
+        And azure login is executed with the following options
+            | option                |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And the terraform cli task is successful
         And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
 
@@ -58,6 +84,13 @@ Feature: terraform plan
             | tenantId       | ten1                   |
             | clientId       | servicePrincipal1      |
             | clientSecret   | servicePrincipalKey123 |
+        And azure cli exists
+        And running command "az login" with the following options returns successful result
+            | option                    |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And running command "terraform plan -input=true -lock=false -no-color -detailed-exitcode" returns successful result with exit code 2
         When the terraform cli task is run        
         Then the terraform cli task executed command "terraform plan -input=true -lock=false -no-color -detailed-exitcode" with the following environment variables
@@ -65,6 +98,12 @@ Feature: terraform plan
             | ARM_TENANT_ID       | ten1                   |
             | ARM_CLIENT_ID       | servicePrincipal1      |
             | ARM_CLIENT_SECRET   | servicePrincipalKey123 |
+        And azure login is executed with the following options
+            | option                |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And the terraform cli task is successful
         And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "2"        
         And pipeline variable "TERRAFORM_PLAN_HAS_CHANGES" is set to "true"
@@ -78,6 +117,13 @@ Feature: terraform plan
             | tenantId       | ten1                   |
             | clientId       | servicePrincipal1      |
             | clientSecret   | servicePrincipalKey123 |
+        And azure cli exists
+        And running command "az login" with the following options returns successful result
+            | option                    |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And running command "terraform plan -input=true -lock=false -no-color -detailed-exitcode" returns successful result with exit code 0
         When the terraform cli task is run        
         Then the terraform cli task executed command "terraform plan -input=true -lock=false -no-color -detailed-exitcode" with the following environment variables
@@ -85,6 +131,12 @@ Feature: terraform plan
             | ARM_TENANT_ID       | ten1                   |
             | ARM_CLIENT_ID       | servicePrincipal1      |
             | ARM_CLIENT_SECRET   | servicePrincipalKey123 |
+        And azure login is executed with the following options
+            | option                |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And the terraform cli task is successful
         And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"        
         And pipeline variable "TERRAFORM_PLAN_HAS_CHANGES" is set to "false"
@@ -98,6 +150,13 @@ Feature: terraform plan
             | tenantId       | ten1                   |
             | clientId       | servicePrincipal1      |
             | clientSecret   | servicePrincipalKey123 |
+        And azure cli exists
+        And running command "az login" with the following options returns successful result
+            | option                    |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And secure file specified with id "6b4ef608-ca4c-4185-92fb-0554b8a2ec72" and name "./src/tests/default.vars"
         And running command "terraform plan -var-file=./src/tests/default.vars" returns successful result
         When the terraform cli task is run
@@ -106,6 +165,12 @@ Feature: terraform plan
             | ARM_TENANT_ID       | ten1                   |
             | ARM_CLIENT_ID       | servicePrincipal1      |
             | ARM_CLIENT_SECRET   | servicePrincipalKey123 |
+        And azure login is executed with the following options
+            | option                |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And the terraform cli task is successful
         And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
 
@@ -118,6 +183,13 @@ Feature: terraform plan
             | tenantId       | ten1                   |
             | clientId       | servicePrincipal1      |
             | clientSecret   | servicePrincipalKey123 |
+        And azure cli exists
+        And running command "az login" with the following options returns successful result
+            | option                    |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And secure file specified with id "6b4ef608-ca4c-4185-92fb-0554b8a2ec72" and name "./src/tests/default.env"
         And running command "terraform plan" returns successful result
         When the terraform cli task is run
@@ -129,6 +201,12 @@ Feature: terraform plan
             | TF_VAR_app-short-name | tffoo  |
             | TF_VAR_region         | eastus |
             | TF_VAR_env-short-name | dev    |
+        And azure login is executed with the following options
+            | option                |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And the terraform cli task is successful
         And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
 

--- a/tasks/terraform-cli/src/tests/features/terraform-refresh.feature
+++ b/tasks/terraform-cli/src/tests/features/terraform-refresh.feature
@@ -20,6 +20,13 @@ Feature: terraform refresh
             | tenantId       | ten1                   |
             | clientId       | servicePrincipal1      |
             | clientSecret   | servicePrincipalKey123 |
+        And azure cli exists
+        And running command "az login" with the following options returns successful result
+            | option                    |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And running command "terraform refresh" returns successful result
         When the terraform cli task is run
         Then the terraform cli task executed command "terraform refresh" with the following environment variables
@@ -27,6 +34,12 @@ Feature: terraform refresh
             | ARM_TENANT_ID       | ten1                   |
             | ARM_CLIENT_ID       | servicePrincipal1      |
             | ARM_CLIENT_SECRET   | servicePrincipalKey123 |
+        And azure login is executed with the following options
+            | option                |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And the terraform cli task is successful
         And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
 
@@ -39,6 +52,13 @@ Feature: terraform refresh
             | tenantId       | ten1                   |
             | clientId       | servicePrincipal1      |
             | clientSecret   | servicePrincipalKey123 |
+        And azure cli exists
+        And running command "az login" with the following options returns successful result
+            | option                    |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And running command "terraform refresh -input=true -lock=false -no-color" returns successful result
         When the terraform cli task is run        
         Then the terraform cli task executed command "terraform refresh -input=true -lock=false -no-color" with the following environment variables
@@ -46,6 +66,12 @@ Feature: terraform refresh
             | ARM_TENANT_ID       | ten1                   |
             | ARM_CLIENT_ID       | servicePrincipal1      |
             | ARM_CLIENT_SECRET   | servicePrincipalKey123 |
+        And azure login is executed with the following options
+            | option                |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And the terraform cli task is successful
         And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
 
@@ -58,6 +84,13 @@ Feature: terraform refresh
             | tenantId       | ten1                   |
             | clientId       | servicePrincipal1      |
             | clientSecret   | servicePrincipalKey123 |
+        And azure cli exists
+        And running command "az login" with the following options returns successful result
+            | option                    |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And secure file specified with id "6b4ef608-ca4c-4185-92fb-0554b8a2ec72" and name "./src/tests/default.vars"
         And running command "terraform refresh -var-file=./src/tests/default.vars" returns successful result
         When the terraform cli task is run
@@ -66,6 +99,12 @@ Feature: terraform refresh
             | ARM_TENANT_ID       | ten1                   |
             | ARM_CLIENT_ID       | servicePrincipal1      |
             | ARM_CLIENT_SECRET   | servicePrincipalKey123 |
+        And azure login is executed with the following options
+            | option                |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And the terraform cli task is successful
         And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
 
@@ -78,6 +117,13 @@ Feature: terraform refresh
             | tenantId       | ten1                   |
             | clientId       | servicePrincipal1      |
             | clientSecret   | servicePrincipalKey123 |
+        And azure cli exists
+        And running command "az login" with the following options returns successful result
+            | option                    |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And secure file specified with id "6b4ef608-ca4c-4185-92fb-0554b8a2ec72" and name "./src/tests/default.env"
         And running command "terraform refresh" returns successful result
         When the terraform cli task is run
@@ -89,5 +135,11 @@ Feature: terraform refresh
             | TF_VAR_app-short-name | tffoo  |
             | TF_VAR_region         | eastus |
             | TF_VAR_env-short-name | dev    |
+        And azure login is executed with the following options
+            | option                |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
         And the terraform cli task is successful
         And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"

--- a/tasks/terraform-cli/src/tests/steps/task.steps.ts
+++ b/tasks/terraform-cli/src/tests/steps/task.steps.ts
@@ -34,6 +34,11 @@ export class TerraformSteps {
         this.assertExecutedCommandWithOptions("terraform init", table);
     }
 
+    @then("azure login is executed with the following options")
+    public assertAzureLoginExecutedWithOptions(table: TableDefinition){
+        this.assertExecutedCommandWithOptions("az login", table);
+    }
+
     @then("an azure storage account is created with the following options")
     public assertAzureStorageAccountCreatedWithOptions(table: TableDefinition){
         this.assertExecutedCommandWithOptions("az storage account create", table);

--- a/templates/local-exec-az-cli/.terraform/.gitignore
+++ b/templates/local-exec-az-cli/.terraform/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/templates/local-exec-az-cli/local-exec-az-cli.vars
+++ b/templates/local-exec-az-cli/local-exec-az-cli.vars
@@ -1,0 +1,4 @@
+location="eastus"
+location_suffix="usea"
+app="tffoo"
+env="dev"

--- a/templates/local-exec-az-cli/main.tf
+++ b/templates/local-exec-az-cli/main.tf
@@ -33,14 +33,14 @@ locals {
   suffix_2 = "core${var.env}${var.location_suffix}${var.app}"
 }
 resource "azurerm_resource_group" "rg_core" {
-  name      = "rg"${locals.suffix}
+  name      = "rg${local.suffix}"
   location  = var.location
 }
 
 resource "azurerm_storage_account" "st_core" {
-  name                      = "st"${locals.suffix_2}
+  name                      = "st${local.suffix_2}"
   location                  = var.location
-  resource_group_name       = "${azurerm_resource_group.rg_core.name}"
+  resource_group_name       = azurerm_resource_group.rg_core.name
   account_kind              = "StorageV2"
   account_tier              = "Standard"
   account_replication_type  = "LRS"

--- a/templates/local-exec-az-cli/main.tf
+++ b/templates/local-exec-az-cli/main.tf
@@ -1,0 +1,52 @@
+variable "location" {
+  type        = string
+  description = "Primary location to which the tracing resources are deployed."
+}
+
+variable "location_suffix" {
+  type        = string
+  description = "Primary location short name to which the tracing resources are deployed."
+}
+
+variable "app" {
+  type        = string
+  description = "An abbreviated version of the application name."
+}
+
+variable "env" {
+  type        = string
+  description = "An abbreviated version of the environment name."
+}
+
+provider "azurerm" {
+    features {
+    }
+}
+
+terraform {
+  backend "azurerm" {}
+  required_version = ">= 0.12"
+}
+
+locals {
+  suffix = "-core-${var.env}-${var.location_suffix}-${var.app}"
+  suffix_2 = "core${var.env}${var.location_suffix}${var.app}"
+}
+resource "azurerm_resource_group" "rg_core" {
+  name      = "rg"${locals.suffix}
+  location  = var.location
+}
+
+resource "azurerm_storage_account" "st_core" {
+  name                      = "st"${locals.suffix_2}
+  location                  = var.location
+  resource_group_name       = "${azurerm_resource_group.rg_core.name}"
+  account_kind              = "StorageV2"
+  account_tier              = "Standard"
+  account_replication_type  = "LRS"
+  
+
+  provisioner "local-exec" {
+          command = "az storage blob service-properties update --account-name ${azurerm_storage_account.st_core.name} --static-website --index-document index.html --404-document index.html"
+  }
+}


### PR DESCRIPTION
Fixes #50 

This change will cause any command that utilizes the azurerm provider to execute az-login ahead of running the terraform command (using the service connection credentials). This is intended initially to allow local-exec provisioner the ability to run azure cli commands as requested in #50. This is useful to perform post deployment configuration changes that may not be possible from terraform directly.

