### PR TITLE
Add flag for running az login

### DIFF
--- a/overview.md
+++ b/overview.md
@@ -68,7 +68,43 @@ When executing commands that interact with Azure such as `plan`, `apply`, and `d
 
 ### **Execute Azure CLI From Local-Exec Provisioner (NEW)**
 
-When an azure service connection is provided, the terraform cli task will run `az login` using the service connection credentials. This is intended to enable templates to execute az cli commands from a `local-exec` provisioner.
+When an azure service connection is provided and `runAzLogin` is set to `true`, the terraform cli task will run `az login` using the service connection credentials. This is intended to enable templates to execute az cli commands from a `local-exec` provisioner.
+
+Setting `runAzLogin` to `true` will indicate the task should execute `az login` with specified service connection.
+
+```yaml
+- task: TerraformCLI
+    displayName: 'terraform apply'
+    inputs:
+        command: apply
+        environmentServiceName: 'My Azure Service Connection'
+        # indicate az login should be run as part of this command
+        runAzLogin: true
+```
+
+Setting `runAzLogin` to `false` will indicate the task should not execute `az login` with specified service connection.
+
+```yaml
+- task: TerraformCLI
+    displayName: 'terraform apply'
+    inputs:
+        command: apply
+        environmentServiceName: 'My Azure Service Connection'
+        # indicate az login should be run as part of this command
+        runAzLogin: true
+```
+
+`runAzLogin`  will default to `false` when not specified; indicating the task should NOT run `az login`
+
+```yaml
+- task: TerraformCLI
+    displayName: 'terraform apply'
+    inputs:
+        command: apply
+        environmentServiceName: 'My Azure Service Connection'
+        # indicate az login should be run as part of this command
+        runAzLogin: true
+```
 
 This should allow the following template configuation to be run using this task
 

--- a/pipelines/test/local_exec_az_cli.yml
+++ b/pipelines/test/local_exec_az_cli.yml
@@ -35,6 +35,7 @@ jobs:
         environmentServiceName: 'env_test'
         secureVarsFile: 85f60b61-3430-4e92-83be-ea5b16eafaaf
         commandOptions: '-out=$(System.DefaultWorkingDirectory)/terraform.tfplan'
+        runAzLogin: true
     - task: TerraformCLI@0
       displayName: 'terraform apply'
       inputs:
@@ -42,6 +43,7 @@ jobs:
         workingDirectory: $(test_templates_dir)
         environmentServiceName: 'env_test'
         commandOptions: '$(System.DefaultWorkingDirectory)/terraform.tfplan'
+        runAzLogin: true
     - task: TerraformCLI@0
       displayName: 'terraform destroy'
       inputs:
@@ -49,3 +51,4 @@ jobs:
         workingDirectory: $(test_templates_dir)
         environmentServiceName: 'env_test'
         secureVarsFile: 85f60b61-3430-4e92-83be-ea5b16eafaaf
+        runAzLogin: true

--- a/tasks/terraform-cli/src/context/azdo-task-context.ts
+++ b/tasks/terraform-cli/src/context/azdo-task-context.ts
@@ -115,6 +115,9 @@ export default class AzdoTaskContext implements ITaskContext {
     get planOrStateFilePath() {
         return this.getInput("inputTargetPlanOrStateFilePath");
     }
+    get runAzLogin() {
+        return this.getBoolInput("runAzLogin");
+    }
     finished() {
         this.finishedAt = process.hrtime(this.startedAt);
         this.runTime = this.finishedAt[1] / 1000000;

--- a/tasks/terraform-cli/src/context/index.ts
+++ b/tasks/terraform-cli/src/context/index.ts
@@ -30,6 +30,7 @@ export interface ITaskContext {
     resourceId: string;
     lockId: string;
     planOrStateFilePath: string;
+    runAzLogin?: boolean
     setVariable: (name: string, val: string, secret?: boolean | undefined) => void;
     runTime: number;
     finished: () => void;

--- a/tasks/terraform-cli/src/context/mock-task-context.ts
+++ b/tasks/terraform-cli/src/context/mock-task-context.ts
@@ -33,6 +33,7 @@ export default class MockTaskContext implements ITaskContext {
     resourceId: string = "";
     lockId: string = "";
     planOrStateFilePath: string = "";
+    runAzLogin?: boolean = false;
     public readonly startedAt: [number, number];
     private _finishedAt: [number, number] | undefined;
     runTime: number = 0;

--- a/tasks/terraform-cli/src/providers/azurerm.ts
+++ b/tasks/terraform-cli/src/providers/azurerm.ts
@@ -33,9 +33,12 @@ export default class AzureRMProvider implements ITerraformProvider {
         process.env['ARM_CLIENT_ID']        = config.clientId;
         process.env['ARM_CLIENT_SECRET']    = config.clientSecret;
 
-        //run az login so provisioners needing az cli can be run.
-        await new CommandPipeline(this.runner)
-            .azLogin()
-            .exec(ctx);
+        if(ctx.runAzLogin){
+            //run az login so provisioners needing az cli can be run.
+            await new CommandPipeline(this.runner)
+                .azLogin()
+                .exec(ctx);
+        }
+        
     }
 }

--- a/tasks/terraform-cli/src/tests/features/terraform-apply.feature
+++ b/tasks/terraform-cli/src/tests/features/terraform-apply.feature
@@ -28,6 +28,7 @@ Feature: terraform apply
             | -t ten1                   |
             | -u servicePrincipal1      |
             | -p servicePrincipalKey123 |
+        And task configured to run az login
         When the terraform cli task is run
         Then the terraform cli task executed command "terraform apply -auto-approve" with the following environment variables
             | ARM_SUBSCRIPTION_ID | sub1                   |
@@ -53,25 +54,13 @@ Feature: terraform apply
             | clientId       | servicePrincipal1      |
             | clientSecret   | servicePrincipalKey123 |
         And running command "terraform apply -auto-approve -input=true -lock=false -no-color" returns successful result
-        And azure cli exists
-        And running command "az login" with the following options returns successful result
-            | option                    |
-            | --service-principal       |
-            | -t ten1                   |
-            | -u servicePrincipal1      |
-            | -p servicePrincipalKey123 |
+        And azure cli not exists
         When the terraform cli task is run        
         Then the terraform cli task executed command "terraform apply -auto-approve -input=true -lock=false -no-color" with the following environment variables
             | ARM_SUBSCRIPTION_ID | sub1                   |
             | ARM_TENANT_ID       | ten1                   |
             | ARM_CLIENT_ID       | servicePrincipal1      |
             | ARM_CLIENT_SECRET   | servicePrincipalKey123 |
-        And azure login is executed with the following options
-            | option                |
-            | --service-principal       |
-            | -t ten1                   |
-            | -u servicePrincipal1      |
-            | -p servicePrincipalKey123 |
         And the terraform cli task is successful
         And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
 
@@ -91,6 +80,7 @@ Feature: terraform apply
             | -t ten1                   |
             | -u servicePrincipal1      |
             | -p servicePrincipalKey123 |
+        And task configured to run az login
         And secure file specified with id "6b4ef608-ca4c-4185-92fb-0554b8a2ec72" and name "./src/tests/default.vars"
         And running command "terraform apply -var-file=./src/tests/default.vars -auto-approve" returns successful result
         When the terraform cli task is run
@@ -124,6 +114,7 @@ Feature: terraform apply
             | -t ten1                   |
             | -u servicePrincipal1      |
             | -p servicePrincipalKey123 |
+        And task configured to run az login
         And secure file specified with id "6b4ef608-ca4c-4185-92fb-0554b8a2ec72" and name "./src/tests/default.env"
         And running command "terraform apply -auto-approve" returns successful result
         When the terraform cli task is run
@@ -160,6 +151,7 @@ Feature: terraform apply
             | -t ten1                   |
             | -u servicePrincipal1      |
             | -p servicePrincipalKey123 |
+        And task configured to run az login
         And running command "terraform apply" returns successful result
         When the terraform cli task is run
         Then the terraform cli task fails with message "Terraform only supports service principal authorization for azure"

--- a/tasks/terraform-cli/src/tests/features/terraform-destroy.feature
+++ b/tasks/terraform-cli/src/tests/features/terraform-destroy.feature
@@ -28,6 +28,7 @@ Feature: terraform destroy
             | -t ten1                   |
             | -u servicePrincipal1      |
             | -p servicePrincipalKey123 |
+        And task configured to run az login
         When the terraform cli task is run
         Then the terraform cli task executed command "terraform destroy -auto-approve" with the following environment variables
             | ARM_SUBSCRIPTION_ID | sub1                   |
@@ -51,14 +52,8 @@ Feature: terraform destroy
             | subscriptionId | sub1                   |
             | tenantId       | ten1                   |
             | clientId       | servicePrincipal1      |
-            | clientSecret   | servicePrincipalKey123 |
-        And azure cli exists
-        And running command "az login" with the following options returns successful result
-            | option                    |
-            | --service-principal       |
-            | -t ten1                   |
-            | -u servicePrincipal1      |
-            | -p servicePrincipalKey123 |
+            | clientSecret   | servicePrincipalKey123 |        
+        And azure cli not exists
         And running command "terraform destroy -auto-approve -input=true -lock=false -no-color" returns successful result
         When the terraform cli task is run
         Then the terraform cli task executed command "terraform destroy -auto-approve -input=true -lock=false -no-color" with the following environment variables
@@ -66,12 +61,6 @@ Feature: terraform destroy
             | ARM_TENANT_ID       | ten1                   |
             | ARM_CLIENT_ID       | servicePrincipal1      |
             | ARM_CLIENT_SECRET   | servicePrincipalKey123 |
-        And azure login is executed with the following options
-            | option                |
-            | --service-principal       |
-            | -t ten1                   |
-            | -u servicePrincipal1      |
-            | -p servicePrincipalKey123 |
         And the terraform cli task is successful
         And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
 
@@ -91,6 +80,7 @@ Feature: terraform destroy
             | -t ten1                   |
             | -u servicePrincipal1      |
             | -p servicePrincipalKey123 |
+        And task configured to run az login
         And secure file specified with id "6b4ef608-ca4c-4185-92fb-0554b8a2ec72" and name "./src/tests/default.vars"
         And running command "terraform destroy -var-file=./src/tests/default.vars -auto-approve" returns successful result
         When the terraform cli task is run
@@ -124,6 +114,7 @@ Feature: terraform destroy
             | -t ten1                   |
             | -u servicePrincipal1      |
             | -p servicePrincipalKey123 |
+        And task configured to run az login
         And secure file specified with id "6b4ef608-ca4c-4185-92fb-0554b8a2ec72" and name "./src/tests/default.env"
         And running command "terraform destroy -auto-approve" returns successful result
         When the terraform cli task is run

--- a/tasks/terraform-cli/src/tests/features/terraform-force-unlock.feature
+++ b/tasks/terraform-cli/src/tests/features/terraform-force-unlock.feature
@@ -18,6 +18,7 @@ Feature: terraform force-unlock
             | -t ten1                   |
             | -u servicePrincipal1      |
             | -p servicePrincipalKey123 |
+        And task configured to run az login
         And force-unlock is run with lock id "3ea12870-968e-b9b9-cf3b-f4c3fbe36684"
         And running command "terraform force-unlock -force 3ea12870-968e-b9b9-cf3b-f4c3fbe36684" returns successful result
         When the terraform cli task is run
@@ -44,13 +45,7 @@ Feature: terraform force-unlock
             | tenantId       | ten1                   |
             | clientId       | servicePrincipal1      |
             | clientSecret   | servicePrincipalKey123 |
-        And azure cli exists
-        And running command "az login" with the following options returns successful result
-            | option                    |
-            | --service-principal       |
-            | -t ten1                   |
-            | -u servicePrincipal1      |
-            | -p servicePrincipalKey123 |
+        And azure cli not exists
         And force-unlock is run with lock id "3ea12870-968e-b9b9-cf3b-f4c3fbe36684"        
         And secure file specified with id "6b4ef608-ca4c-4185-92fb-0554b8a2ec72" and name "./src/tests/default.env"
         And running command "terraform force-unlock -force 3ea12870-968e-b9b9-cf3b-f4c3fbe36684" returns successful result
@@ -63,11 +58,5 @@ Feature: terraform force-unlock
             | TF_VAR_app-short-name | tffoo  |
             | TF_VAR_region         | eastus |
             | TF_VAR_env-short-name | dev    |
-        And azure login is executed with the following options
-            | option                |
-            | --service-principal       |
-            | -t ten1                   |
-            | -u servicePrincipal1      |
-            | -p servicePrincipalKey123 |
         And the terraform cli task is successful
         And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"

--- a/tasks/terraform-cli/src/tests/features/terraform-import.feature
+++ b/tasks/terraform-cli/src/tests/features/terraform-import.feature
@@ -29,6 +29,7 @@ Feature: terraform import
             | -t ten1                   |
             | -u servicePrincipal1      |
             | -p servicePrincipalKey123 |
+        And task configured to run az login
         And resource target provided with address "azurerm_resource_group.rg" and id "/subscriptions/sub1/resourceGroups/rg-tffoo-dev-eastus"
         And running command "terraform import azurerm_resource_group.rg /subscriptions/sub1/resourceGroups/rg-tffoo-dev-eastus" returns successful result
         When the terraform cli task is run
@@ -55,13 +56,7 @@ Feature: terraform import
             | tenantId       | ten1                   |
             | clientId       | servicePrincipal1      |
             | clientSecret   | servicePrincipalKey123 |
-        And azure cli exists
-        And running command "az login" with the following options returns successful result
-            | option                    |
-            | --service-principal       |
-            | -t ten1                   |
-            | -u servicePrincipal1      |
-            | -p servicePrincipalKey123 |
+        And azure cli not exists
         And resource target provided with address "azurerm_resource_group.rg" and id "/subscriptions/sub1/resourceGroups/rg-tffoo-dev-eastus"
         And running command "terraform import -input=true -lock=false -no-color azurerm_resource_group.rg /subscriptions/sub1/resourceGroups/rg-tffoo-dev-eastus" returns successful result
         When the terraform cli task is run        
@@ -70,12 +65,6 @@ Feature: terraform import
             | ARM_TENANT_ID       | ten1                   |
             | ARM_CLIENT_ID       | servicePrincipal1      |
             | ARM_CLIENT_SECRET   | servicePrincipalKey123 |
-        And azure login is executed with the following options
-            | option                |
-            | --service-principal       |
-            | -t ten1                   |
-            | -u servicePrincipal1      |
-            | -p servicePrincipalKey123 |
         And the terraform cli task is successful
         And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
 
@@ -95,6 +84,7 @@ Feature: terraform import
             | -t ten1                   |
             | -u servicePrincipal1      |
             | -p servicePrincipalKey123 |
+        And task configured to run az login
         And secure file specified with id "6b4ef608-ca4c-4185-92fb-0554b8a2ec72" and name "./src/tests/default.vars"
         And resource target provided with address "azurerm_resource_group.rg" and id "/subscriptions/sub1/resourceGroups/rg-tffoo-dev-eastus"
         And running command "terraform import -var-file=./src/tests/default.vars azurerm_resource_group.rg /subscriptions/sub1/resourceGroups/rg-tffoo-dev-eastus" returns successful result
@@ -129,6 +119,7 @@ Feature: terraform import
             | -t ten1                   |
             | -u servicePrincipal1      |
             | -p servicePrincipalKey123 |
+        And task configured to run az login
         And secure file specified with id "6b4ef608-ca4c-4185-92fb-0554b8a2ec72" and name "./src/tests/default.env"
         And resource target provided with address "azurerm_resource_group.rg" and id "/subscriptions/sub1/resourceGroups/rg-tffoo-dev-eastus"
         And running command "terraform import azurerm_resource_group.rg /subscriptions/sub1/resourceGroups/rg-tffoo-dev-eastus" returns successful result

--- a/tasks/terraform-cli/src/tests/features/terraform-plan.feature
+++ b/tasks/terraform-cli/src/tests/features/terraform-plan.feature
@@ -27,6 +27,7 @@ Feature: terraform plan
             | -t ten1                   |
             | -u servicePrincipal1      |
             | -p servicePrincipalKey123 |
+        And task configured to run az login
         And running command "terraform plan" returns successful result
         When the terraform cli task is run
         Then the terraform cli task executed command "terraform plan" with the following environment variables
@@ -59,6 +60,7 @@ Feature: terraform plan
             | -t ten1                   |
             | -u servicePrincipal1      |
             | -p servicePrincipalKey123 |
+        And task configured to run az login
         And running command "terraform plan -input=true -lock=false -no-color" returns successful result
         When the terraform cli task is run        
         Then the terraform cli task executed command "terraform plan -input=true -lock=false -no-color" with the following environment variables
@@ -84,13 +86,7 @@ Feature: terraform plan
             | tenantId       | ten1                   |
             | clientId       | servicePrincipal1      |
             | clientSecret   | servicePrincipalKey123 |
-        And azure cli exists
-        And running command "az login" with the following options returns successful result
-            | option                    |
-            | --service-principal       |
-            | -t ten1                   |
-            | -u servicePrincipal1      |
-            | -p servicePrincipalKey123 |
+        And azure cli not exists
         And running command "terraform plan -var-file=./default.vars" returns successful result
         When the terraform cli task is run        
         Then the terraform cli task executed command "terraform plan -var-file=./default.vars" with the following environment variables
@@ -98,12 +94,6 @@ Feature: terraform plan
             | ARM_TENANT_ID       | ten1                   |
             | ARM_CLIENT_ID       | servicePrincipal1      |
             | ARM_CLIENT_SECRET   | servicePrincipalKey123 |
-        And azure login is executed with the following options
-            | option                |
-            | --service-principal       |
-            | -t ten1                   |
-            | -u servicePrincipal1      |
-            | -p servicePrincipalKey123 |
         And the terraform cli task is successful
         And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
 
@@ -123,6 +113,7 @@ Feature: terraform plan
             | -t ten1                   |
             | -u servicePrincipal1      |
             | -p servicePrincipalKey123 |
+        And task configured to run az login
         And running command "terraform plan -input=true -lock=false -no-color -detailed-exitcode" returns successful result with exit code 2
         When the terraform cli task is run        
         Then the terraform cli task executed command "terraform plan -input=true -lock=false -no-color -detailed-exitcode" with the following environment variables
@@ -156,6 +147,7 @@ Feature: terraform plan
             | -t ten1                   |
             | -u servicePrincipal1      |
             | -p servicePrincipalKey123 |
+        And task configured to run az login
         And running command "terraform plan -input=true -lock=false -no-color -detailed-exitcode" returns successful result with exit code 0
         When the terraform cli task is run        
         Then the terraform cli task executed command "terraform plan -input=true -lock=false -no-color -detailed-exitcode" with the following environment variables
@@ -189,6 +181,7 @@ Feature: terraform plan
             | -t ten1                   |
             | -u servicePrincipal1      |
             | -p servicePrincipalKey123 |
+        And task configured to run az login
         And secure file specified with id "6b4ef608-ca4c-4185-92fb-0554b8a2ec72" and name "./src/tests/default.vars"
         And running command "terraform plan -var-file=./src/tests/default.vars" returns successful result
         When the terraform cli task is run
@@ -222,6 +215,7 @@ Feature: terraform plan
             | -t ten1                   |
             | -u servicePrincipal1      |
             | -p servicePrincipalKey123 |
+        And task configured to run az login
         And secure file specified with id "6b4ef608-ca4c-4185-92fb-0554b8a2ec72" and name "./src/tests/default.env"
         And running command "terraform plan" returns successful result
         When the terraform cli task is run

--- a/tasks/terraform-cli/src/tests/features/terraform-refresh.feature
+++ b/tasks/terraform-cli/src/tests/features/terraform-refresh.feature
@@ -27,6 +27,7 @@ Feature: terraform refresh
             | -t ten1                   |
             | -u servicePrincipal1      |
             | -p servicePrincipalKey123 |
+        And task configured to run az login
         And running command "terraform refresh" returns successful result
         When the terraform cli task is run
         Then the terraform cli task executed command "terraform refresh" with the following environment variables
@@ -52,13 +53,7 @@ Feature: terraform refresh
             | tenantId       | ten1                   |
             | clientId       | servicePrincipal1      |
             | clientSecret   | servicePrincipalKey123 |
-        And azure cli exists
-        And running command "az login" with the following options returns successful result
-            | option                    |
-            | --service-principal       |
-            | -t ten1                   |
-            | -u servicePrincipal1      |
-            | -p servicePrincipalKey123 |
+        And azure cli not exists
         And running command "terraform refresh -input=true -lock=false -no-color" returns successful result
         When the terraform cli task is run        
         Then the terraform cli task executed command "terraform refresh -input=true -lock=false -no-color" with the following environment variables
@@ -66,12 +61,6 @@ Feature: terraform refresh
             | ARM_TENANT_ID       | ten1                   |
             | ARM_CLIENT_ID       | servicePrincipal1      |
             | ARM_CLIENT_SECRET   | servicePrincipalKey123 |
-        And azure login is executed with the following options
-            | option                |
-            | --service-principal       |
-            | -t ten1                   |
-            | -u servicePrincipal1      |
-            | -p servicePrincipalKey123 |
         And the terraform cli task is successful
         And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
 
@@ -91,6 +80,7 @@ Feature: terraform refresh
             | -t ten1                   |
             | -u servicePrincipal1      |
             | -p servicePrincipalKey123 |
+        And task configured to run az login
         And secure file specified with id "6b4ef608-ca4c-4185-92fb-0554b8a2ec72" and name "./src/tests/default.vars"
         And running command "terraform refresh -var-file=./src/tests/default.vars" returns successful result
         When the terraform cli task is run
@@ -124,6 +114,7 @@ Feature: terraform refresh
             | -t ten1                   |
             | -u servicePrincipal1      |
             | -p servicePrincipalKey123 |
+        And task configured to run az login
         And secure file specified with id "6b4ef608-ca4c-4185-92fb-0554b8a2ec72" and name "./src/tests/default.env"
         And running command "terraform refresh" returns successful result
         When the terraform cli task is run

--- a/tasks/terraform-cli/src/tests/steps/task-answers.steps.ts
+++ b/tasks/terraform-cli/src/tests/steps/task-answers.steps.ts
@@ -45,6 +45,11 @@ export class TaskAnswersSteps {
         this.answerToolExists("az", true);
     }
 
+    @given("azure cli not exists")
+    public answerAzureCliNotExists(){
+        this.answerToolExists("az", false);
+    }
+
     @given("running command {string} returns successful result")
     public runningCommandReturnsSuccessfulResult(command: string){
         this.answers.exec[command] = <TaskLibAnswerExecResult>{

--- a/tasks/terraform-cli/src/tests/steps/task-context.steps.ts
+++ b/tasks/terraform-cli/src/tests/steps/task-context.steps.ts
@@ -87,6 +87,11 @@ export class TaskContextSteps {
         this.ctx.planOrStateFilePath = planOrStateFile;
     }
 
+    @given("task configured to run az login")
+    public taskConfiguredToRunAzLogin(){
+        this.ctx.runAzLogin = true;
+    }
+
     @then("pipeline variable {string} is set to {string}")
     public pipelineVariableIsSet(key: string, value: string){
         const variable = this.ctx.variables[key];

--- a/tasks/terraform-cli/task.json
+++ b/tasks/terraform-cli/task.json
@@ -89,6 +89,16 @@
             "helpMarkDown": "Select an Azure service connection if you would like the azurerm provider configured for you (using the service principal credentials configured in the selected service connection). **This field is optional.** Leave empty should you choose to self-configure the provider(s) used. Provider environment variables can be configured securely by selecting an env file from the `Secured Variables File` pick list."
         },
         {
+            "name": "runAzLogin",
+            "type": "boolean",
+            "label": "Run Azure CLI Login",
+            "defaultValue": "false",
+            "required": false,
+            "visibleRule": "command = plan || command = apply || command = destroy || command = refresh || command = import",
+            "helpMarkDown": "If checked, task will execute az login to enable local-exec provisioner to run az cli commands",
+            "groupName": "backendAzureRm"
+        },
+        {
             "name": "secureVarsFile",
             "type": "secureFile",
             "label": "Secured Variables File (Secrets)",


### PR DESCRIPTION
Fixes #196 

This change will add a flag to explicitly indicate when az login should be run. #196 indicates that there are cases where the azurerm provider is being used on agents where az cli is not available. This causes pipelines to fail. This change will make the task by default not run az login.

runAzLogin input has been added to indicate when az login should be run

Setting to true will indicate az login should be run
```yaml
    - task: TerraformCLI@0
      displayName: 'terraform apply'
      inputs:
        command: apply
        workingDirectory: $(test_templates_dir)
        environmentServiceName: 'env_test'
        commandOptions: '$(System.DefaultWorkingDirectory)/terraform.tfplan'
        # run az login
        runAzLogin: true
```

Not specifying runAzLogin will default to false meaning az login will not be run
```yaml
    - task: TerraformCLI@0
      displayName: 'terraform apply'
      inputs:
        command: apply
        workingDirectory: $(test_templates_dir)
        environmentServiceName: 'env_test'
        commandOptions: '$(System.DefaultWorkingDirectory)/terraform.tfplan'
        # run az login
```

Setting to false will indicate az login should be NOT run
```yaml
    - task: TerraformCLI@0
      displayName: 'terraform apply'
      inputs:
        command: apply
        workingDirectory: $(test_templates_dir)
        environmentServiceName: 'env_test'
        commandOptions: '$(System.DefaultWorkingDirectory)/terraform.tfplan'
        # do not run az login
        runAzLogin: false
```