### PR TITLE
check existence of resource changes property before detecting destroy

### DIFF
--- a/tasks/terraform-cli/src/commands/tf-show.ts
+++ b/tasks/terraform-cli/src/commands/tf-show.ts
@@ -44,14 +44,17 @@ export class TerraformShow implements ICommand {
         let jsonResult = JSON.parse(resultNoEol);
         const deleteValue = "delete";
 
-        for (let resourceChange  of jsonResult.resource_changes) {
-            if  (resourceChange.change.actions.includes(deleteValue))
-            {
-                this.setDestroyDetectedFlag(ctx, true);
-                this.logger.warning("Destroy detected!")
-                return;
+        if(jsonResult.resource_changes){
+            for (let resourceChange  of jsonResult.resource_changes) {
+                if  (resourceChange.change.actions.includes(deleteValue))
+                {
+                    this.setDestroyDetectedFlag(ctx, true);
+                    this.logger.warning("Destroy detected!")
+                    return;
+                }
             }
         }
+        
         this.logger.debug("No destroy detected")
         this.setDestroyDetectedFlag(ctx, false);
     }

--- a/tasks/terraform-cli/src/tests/features/terraform-show.feature
+++ b/tasks/terraform-cli/src/tests/features/terraform-show.feature
@@ -81,3 +81,14 @@ Feature: terraform show
         And the terraform cli task fails with message "terraform show command supports only env files, no tfvars are allowed during this stage."
         And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "1"
         And pipeline variable "TERRAFORM_PLAN_HAS_DESTROY_CHANGES" is not set
+
+        Scenario: show tf plan file with output only
+        Given terraform exists
+        And terraform command is "show"
+        And running command "terraform show -json show.plan" returns successful result with stdout from file "./src/tests/stdout_tf_show_tfplan_output_only.json"
+        And the target plan or state file is "show.plan"
+        When the terraform cli task is run
+        Then the terraform cli task executed command "terraform show -json show.plan"
+        And the terraform cli task is successful
+        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
+        And pipeline variable "TERRAFORM_PLAN_HAS_DESTROY_CHANGES" is set to "false"

--- a/tasks/terraform-cli/src/tests/stdout_tf_show_tfplan_output_only.json
+++ b/tasks/terraform-cli/src/tests/stdout_tf_show_tfplan_output_only.json
@@ -1,0 +1,23 @@
+{
+    "format_version": "0.1",
+    "terraform_version": "0.13.4",
+    "planned_values": {
+        "outputs": {
+            "some_string": {
+                "sensitive": false,
+                "value": "NOT_EXISTS"
+            }
+        },
+        "root_module": {}
+    },
+    "output_changes": {
+        "some_string": {
+            "actions": [
+                "create"
+            ],
+            "before": null,
+            "after": "NOT_EXISTS",
+            "after_unknown": false
+        }
+    }
+}


### PR DESCRIPTION
Resolves #23 (hopefully)

While unable to reproduce the exact error message, in response to #23, an error was discovered when the plan does not contain any resource changes. This change checks the existence of resource changes property before iterating on it to detect destroy operations.