### PR TITLE
regex fixed to match number >9

### DIFF
--- a/tasks/terraform-cli/src/commands/tf-plan.ts
+++ b/tasks/terraform-cli/src/commands/tf-plan.ts
@@ -15,7 +15,7 @@ const planHasChangesRe = /^Terraform will perform the following actions:/
 //Plan: 1 to add, 1 to change, 1 to destroy.
 //Plan: 0 to add, 1 to change, 1 to destroy.
 //Plan: 0 to add, 1 to change, 0 to destroy.
-const planSummaryLineRe = /^Plan: ([0-9]?) to add, ([0-9]?) to change, ([0-9]?) to destroy.$/
+const planSummaryLineRe = /^Plan: ([0-9]+) to add, ([0-9]+) to change, ([0-9]+) to destroy.$/
 const planSummaryEndRe = /^[-]+$/
 
 // The lines can have shell color codes in them

--- a/tasks/terraform-cli/src/tests/features/publish-plan-results/plan-output-with-more-than-nine-changes.txt
+++ b/tasks/terraform-cli/src/tests/features/publish-plan-results/plan-output-with-more-than-nine-changes.txt
@@ -1,0 +1,42 @@
+[0m[1mazurerm_resource_group.test_02: Refreshing state... [id=/subscriptions/00000000-aaaa-0000-0000-aaaaaaaaaaaa/resourceGroups/test-02-rg][0m
+[0m[1mazurerm_resource_group.test_01: Refreshing state... [id=/subscriptions/00000000-aaaa-0000-0000-aaaaaaaaaaaa/resourceGroups/test-01-rg][0m
+
+Terraform will perform the following actions:
+
+[1m  # azurerm_resource_group.test_01[0m will be updated in-place[0m[0m
+[0m  [33m~[0m[0m resource "azurerm_resource_group" "test_01" {
+        [1m[0mid[0m[0m       = "/subscriptions/00000000-aaaa-0000-0000-aaaaaaaaaaaa/resourceGroups/test-01-rg"
+        [1m[0mname[0m[0m     = "test-01-rg"
+      [33m~[0m [0m[1m[0mtags[0m[0m     = {
+          [33m~[0m [0m"test" = "test" [33m->[0m [0m"test1"
+        }
+        [90m# (1 unchanged attribute hidden)[0m[0m
+    }
+
+[1m  # azurerm_resource_group.test_02[0m will be [1m[31mdestroyed[0m[0m
+[0m  [31m-[0m[0m resource "azurerm_resource_group" "test_02" {
+      [31m-[0m [0m[1m[0mid[0m[0m       = "/subscriptions/00000000-aaaa-0000-0000-aaaaaaaaaaaa/resourceGroups/test-02-rg" [90m->[0m [0m[90mnull[0m[0m
+      [31m-[0m [0m[1m[0mlocation[0m[0m = "eastus2" [90m->[0m [0m[90mnull[0m[0m
+      [31m-[0m [0m[1m[0mname[0m[0m     = "test-02-rg" [90m->[0m [0m[90mnull[0m[0m
+      [31m-[0m [0m[1m[0mtags[0m[0m     = {} [90m->[0m [0m[90mnull[0m[0m
+    }
+
+[1m  # azurerm_resource_group.test_03[0m will be created[0m[0m
+[0m  [32m+[0m[0m resource "azurerm_resource_group" "test_03" {
+      [32m+[0m [0m[1m[0mid[0m[0m       = (known after apply)
+      [32m+[0m [0m[1m[0mlocation[0m[0m = "eastus2"
+      [32m+[0m [0m[1m[0mname[0m[0m     = "test-03-rg"
+    }
+
+[0m[1mPlan:[0m 152 to add, 83 to change, 13 to destroy.[0m
+[0m
+[1mChanges to Outputs:[0m
+  [32m+[0m [0m[1m[0mthree[0m[0m = (known after apply)
+  [31m-[0m [0m[1m[0mtwo[0m[0m   = "/subscriptions/00000000-aaaa-0000-0000-aaaaaaaaaaaa/resourceGroups/test-02-rg" [90m->[0m [0m[90mnull[0m[0m[0m
+
+------------------------------------------------------------------------
+
+This plan was saved to: tfplan
+
+To perform exactly these actions, run the following command to apply:
+    terraform apply "tfplan"

--- a/tasks/terraform-cli/src/tests/features/publish-plan-results/plan-summary-with-more-than-nine-changes.txt
+++ b/tasks/terraform-cli/src/tests/features/publish-plan-results/plan-summary-with-more-than-nine-changes.txt
@@ -1,0 +1,32 @@
+Terraform will perform the following actions:
+
+[1m  # azurerm_resource_group.test_01[0m will be updated in-place[0m[0m
+[0m  [33m~[0m[0m resource "azurerm_resource_group" "test_01" {
+        [1m[0mid[0m[0m       = "/subscriptions/00000000-aaaa-0000-0000-aaaaaaaaaaaa/resourceGroups/test-01-rg"
+        [1m[0mname[0m[0m     = "test-01-rg"
+      [33m~[0m [0m[1m[0mtags[0m[0m     = {
+          [33m~[0m [0m"test" = "test" [33m->[0m [0m"test1"
+        }
+        [90m# (1 unchanged attribute hidden)[0m[0m
+    }
+
+[1m  # azurerm_resource_group.test_02[0m will be [1m[31mdestroyed[0m[0m
+[0m  [31m-[0m[0m resource "azurerm_resource_group" "test_02" {
+      [31m-[0m [0m[1m[0mid[0m[0m       = "/subscriptions/00000000-aaaa-0000-0000-aaaaaaaaaaaa/resourceGroups/test-02-rg" [90m->[0m [0m[90mnull[0m[0m
+      [31m-[0m [0m[1m[0mlocation[0m[0m = "eastus2" [90m->[0m [0m[90mnull[0m[0m
+      [31m-[0m [0m[1m[0mname[0m[0m     = "test-02-rg" [90m->[0m [0m[90mnull[0m[0m
+      [31m-[0m [0m[1m[0mtags[0m[0m     = {} [90m->[0m [0m[90mnull[0m[0m
+    }
+
+[1m  # azurerm_resource_group.test_03[0m will be created[0m[0m
+[0m  [32m+[0m[0m resource "azurerm_resource_group" "test_03" {
+      [32m+[0m [0m[1m[0mid[0m[0m       = (known after apply)
+      [32m+[0m [0m[1m[0mlocation[0m[0m = "eastus2"
+      [32m+[0m [0m[1m[0mname[0m[0m     = "test-03-rg"
+    }
+
+[0m[1mPlan:[0m 152 to add, 83 to change, 13 to destroy.[0m
+[0m
+[1mChanges to Outputs:[0m
+  [32m+[0m [0m[1m[0mthree[0m[0m = (known after apply)
+  [31m-[0m [0m[1m[0mtwo[0m[0m   = "/subscriptions/00000000-aaaa-0000-0000-aaaaaaaaaaaa/resourceGroups/test-02-rg" [90m->[0m [0m[90mnull[0m[0m[0m

--- a/tasks/terraform-cli/src/tests/features/publish-plan-results/publish-plan-results.feature
+++ b/tasks/terraform-cli/src/tests/features/publish-plan-results/publish-plan-results.feature
@@ -36,3 +36,12 @@ Feature: publish plan results
         And a plan named "test_deploy.tfplan" is published with the following content from file "./src/tests/features/publish-plan-results/plan-summary-with-1-unchanged-1-to-add.txt"
         And 2 plans are published
 
+    Scenario: publish plan results with more than 9 changes
+        Given terraform exists
+        And terraform command is "plan" with options "-detailed-exitcode"
+        And running command "terraform plan -detailed-exitcode" returns successful result with exit code 2 and stdout from file "./src/tests/features/publish-plan-results/plan-output-with-more-than-nine-changes.txt"
+        And publish plan result is "test_deploy.tfplan"
+        When the terraform cli task is run
+        Then the terraform cli task is successful
+        And a plan named "test_deploy.tfplan" is published with the following content from file "./src/tests/features/publish-plan-results/plan-summary-with-more-than-nine-changes.txt"
+


### PR DESCRIPTION
While testing the changes I tried to do I found a bug. If the numbers of changed (create, destroy, update) resources exceed 9 the regex will not find them causing the code to never even look for the end line.

![image](https://user-images.githubusercontent.com/13867326/118382128-94e9de80-b5f2-11eb-9310-d51203321358.png)
