### PR TITLE
For "output" set variables both as isOutput=true and isOutput=false

### DIFF
--- a/tasks/terraform-cli/src/commands/tf-output.ts
+++ b/tasks/terraform-cli/src/commands/tf-output.ts
@@ -25,6 +25,7 @@ export class TerraformOutput implements ICommand {
                 const outputVariable = outputVariables[key];
                 if(["string", "number", "bool"].includes(outputVariable.type)){
                     // set pipeline variable so its available to subsequent steps
+                    ctx.setVariable(`TF_OUT_${key.toUpperCase()}`, outputVariable.value, outputVariable.sensitive, false);
                     ctx.setVariable(`TF_OUT_${key.toUpperCase()}`, outputVariable.value, outputVariable.sensitive, true);
                     if ( outputVariable.sensitive ) {
                         console.log(`TF_OUT_${key.toUpperCase()}`, "=", "********* (sensitive)");

--- a/tasks/terraform-cli/src/tests/features/terraform-output/terraform-output.feature
+++ b/tasks/terraform-cli/src/tests/features/terraform-output/terraform-output.feature
@@ -46,7 +46,9 @@ Feature: terraform output
         When the terraform cli task is run
         Then the terraform cli task executed command "terraform output -json -no-color"
         And the terraform cli task is successful
+        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
         And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0" as output
+        And pipeline variable "TF_OUT_SOME_STRING" is set to "some-string-value"
         And pipeline variable "TF_OUT_SOME_STRING" is set to "some-string-value" as output
         And the following info messages are logged
             | TF_OUT_SOME_STRING = some-string-value |

--- a/tasks/terraform-cli/src/tests/features/terraform-output/terraform-output.feature
+++ b/tasks/terraform-cli/src/tests/features/terraform-output/terraform-output.feature
@@ -9,10 +9,15 @@ Feature: terraform output
         When the terraform cli task is run
         Then the terraform cli task executed command "terraform output -json"
         And the terraform cli task is successful
+        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
         And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0" as output
+        And pipeline variable "TF_OUT_SOME_BOOL" is set to "true"
         And pipeline variable "TF_OUT_SOME_BOOL" is set to "true" as output
+        And pipeline variable "TF_OUT_SOME_STRING" is set to "some-string-value"
         And pipeline variable "TF_OUT_SOME_STRING" is set to "some-string-value" as output
+        And pipeline secret "TF_OUT_SOME_SECRET_STRING" is set to "some-secret-string-value"
         And pipeline secret "TF_OUT_SOME_SECRET_STRING" is set to "some-secret-string-value" as output
+        And pipeline variable "TF_OUT_SOME_NUMBER" is set to "1"
         And pipeline variable "TF_OUT_SOME_NUMBER" is set to "1" as output
         And the following warnings are logged
             | Currently only keys of type "string", "number", and "bool" will returned. The key "some_tuple" is not supported! |
@@ -30,6 +35,7 @@ Feature: terraform output
         When the terraform cli task is run
         Then the terraform cli task executed command "terraform output -json"
         And the terraform cli task is successful
+        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
         And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0" as output
         And no pipeline variables starting with "TF_OUT" are set
 


### PR DESCRIPTION
This is an attempt to to update the "output" command to set both local variables and output variables. Related to issue #46.  I don't actually know how to test this so it's been made "blind", but I hope it helps.