### PR TITLE
Emit pipeline variables as outputs and variables

### DIFF
--- a/pipelines/pipeline-alpha.yml
+++ b/pipelines/pipeline-alpha.yml
@@ -26,5 +26,4 @@ stages:
     parameters:
       stage: alpha
       scenarios:
-        - smoke_test.yml
-        - switch_workspaces.yml
+        - plan_has_changes.yml

--- a/pipelines/pipeline-alpha.yml
+++ b/pipelines/pipeline-alpha.yml
@@ -27,3 +27,4 @@ stages:
       stage: alpha
       scenarios:
         - plan_has_changes.yml
+        - plan_has_changes_output.yml

--- a/pipelines/test/plan_has_changes.yml
+++ b/pipelines/test/plan_has_changes.yml
@@ -1,0 +1,43 @@
+parameters:
+  stage: ''
+
+jobs:
+- job: plan_has_changes_${{ parameters.stage }}
+  steps:
+    - task: DownloadPipelineArtifact@2
+      displayName: download terraform templates
+      inputs: 
+        artifact: terraform_templates
+        path: $(terraform_extension_dir)
+    - task: charleszipp.azure-pipelines-tasks-terraform-${{ parameters.stage }}.azure-pipelines-tasks-terraform-installer.TerraformInstaller@0
+      displayName: install terraform
+      inputs:
+        terraformVersion: 0.15.0
+    - task: charleszipp.azure-pipelines-tasks-terraform-${{ parameters.stage }}.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
+      displayName: 'terraform init'
+      inputs:
+        command: init
+        workingDirectory: $(terraform_templates_dir)
+        backendType: azurerm
+        backendServiceArm: 'env_test'
+        ensureBackend: true
+        backendAzureRmResourceGroupName: rg-trfrm-${{ parameters.stage }}-eus-czp
+        backendAzureRmResourceGroupLocation: eastus
+        backendAzureRmStorageAccountName: sttrfrm${{ parameters.stage }}eusczp
+        backendAzureRmStorageAccountSku: Standard_RAGRS
+        backendAzureRmContainerName: azure-pipelines-terraform
+        backendAzureRmKey: publish_plan_results.tfstate
+    - task: charleszipp.azure-pipelines-tasks-terraform-${{ parameters.stage }}.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
+      displayName: 'terraform plan'
+      inputs:
+        command: plan
+        workingDirectory: $(terraform_templates_dir)
+        environmentServiceName: 'env_test'
+        secureVarsFile: $(tf_variables_secure_file)
+        commandOptions: '-out=$(System.DefaultWorkingDirectory)/terraform.tfplan -detailed-exitcode'
+    - task: PowerShell@2
+      displayName: 'Set variable output_terraform_plan_has_changes'
+      inputs:
+        targetType: 'inline'
+        script: |
+          Write-Host "Terraform changes detected: $(TERRAFORM_PLAN_HAS_CHANGES)"

--- a/pipelines/test/plan_has_changes.yml
+++ b/pipelines/test/plan_has_changes.yml
@@ -26,7 +26,7 @@ jobs:
         backendAzureRmStorageAccountName: sttrfrm${{ parameters.stage }}eusczp
         backendAzureRmStorageAccountSku: Standard_RAGRS
         backendAzureRmContainerName: azure-pipelines-terraform
-        backendAzureRmKey: publish_plan_results.tfstate
+        backendAzureRmKey: plan_has_changes.tfstate
     - task: charleszipp.azure-pipelines-tasks-terraform-${{ parameters.stage }}.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
       displayName: 'terraform plan'
       inputs:

--- a/pipelines/test/plan_has_changes_output.yml
+++ b/pipelines/test/plan_has_changes_output.yml
@@ -1,0 +1,13 @@
+jobs:
+- job: plan_has_changes_output_${{ parameters.stage }}
+  dependsOn: plan_has_changes_${{ parameters.stage }}
+  variables:
+      TERRAFORM_PLAN_HAS_CHANGES: $[ dependencies.plan_has_changes_${{ parameters.stage }}.outputs['plan_has_changes_${{ parameters.stage }}.TERRAFORM_PLAN_HAS_CHANGES'] ]
+  steps:
+    - task: PowerShell@2
+      displayName: 'Set variable output_terraform_plan_has_changes'
+      inputs:
+        targetType: 'inline'
+        script: |
+          Write-Host "Terraform changes detected: $(TERRAFORM_PLAN_HAS_CHANGES)"
+

--- a/tasks/terraform-cli/src/context/azdo-task-context.ts
+++ b/tasks/terraform-cli/src/context/azdo-task-context.ts
@@ -146,8 +146,8 @@ export default class AzdoTaskContext implements ITaskContext {
     setVariable(name: string, val: string, secret?: boolean | undefined, isOutput?: boolean | undefined){
         if(isOutput){
             // set as variable so its still accessible via `variable[]` syntax and `output[]` syntax
-            this.setVariable(name, val, secret, false);
-            this.setVariable(name, val, secret, true);            
+            //this.setVariable(name, val, secret, true);            
         }
+        this.setVariable(name, val, secret, false);
     }
 }

--- a/tasks/terraform-cli/src/context/azdo-task-context.ts
+++ b/tasks/terraform-cli/src/context/azdo-task-context.ts
@@ -9,7 +9,7 @@ export default class AzdoTaskContext implements ITaskContext {
     private getEndpointAuthorizationParameter: (id: string, key: string, optional: boolean) => string;
     private getSecureFileName: (id: string) => string;
     public getVariable: (name: string) => string | undefined;
-    public setVariable: (name: string, val: string, secret?: boolean | undefined, isOutput?: boolean | undefined) => void;
+    // public setVariable: (name: string, val: string, secret?: boolean | undefined, isOutput?: boolean | undefined) => void;
     public startedAt: [number, number];
     public finishedAt: [number, number] | undefined;
     public runTime: number = 0;
@@ -24,7 +24,7 @@ export default class AzdoTaskContext implements ITaskContext {
         this.getEndpointDataParameter = <(id: string, key: string, optional: boolean) => string>tasks.getEndpointDataParameter;
         this.getEndpointAuthorizationParameter = <(id: string, key: string, optional: boolean) => string>tasks.getEndpointAuthorizationParameter;
         this.getVariable = tasks.getVariable;
-        this.setVariable = tasks.setVariable;
+        // this.setVariable = tasks.setVariable;
         this.getSecureFileName = <(id: string) => string>tasks.getSecureFileName;
         this.startedAt = process.hrtime();
     }
@@ -142,5 +142,12 @@ export default class AzdoTaskContext implements ITaskContext {
         this.terraformVersionMajor = major;
         this.terraformVersionMinor = minor;
         this.terraformVersionPatch = patch;
+    }
+    setVariable(name: string, val: string, secret?: boolean | undefined, isOutput?: boolean | undefined){
+        if(isOutput){
+            // set as variable so its still accessible via `variable[]` syntax and `output[]` syntax
+            this.setVariable(name, val, secret, false);
+            this.setVariable(name, val, secret, true);            
+        }
     }
 }

--- a/tasks/terraform-cli/src/context/mock-task-context.ts
+++ b/tasks/terraform-cli/src/context/mock-task-context.ts
@@ -49,10 +49,14 @@ export default class MockTaskContext implements ITaskContext {
         this.startedAt = process.hrtime();
     }
 
-    public readonly variables: { [key: string]: { val: string, secret?: boolean, isOutput?: boolean }} = {};
+    public readonly variables: { [key: string]: { val: string, secret?: boolean }} = {};
+    public readonly outputs: { [key: string]: { val: string, secret?: boolean }} = {};
 
     public setVariable(name: string, val: string, secret?: boolean, isOutput?: boolean){
-        this.variables[name] = { val, secret, isOutput};
+        if(isOutput){
+            this.outputs[name] = { val, secret};
+        }
+        this.variables[name] = { val, secret};
     }
 
     get finishedAt(){

--- a/tasks/terraform-cli/src/tests/features/terraform-output/terraform-output.feature
+++ b/tasks/terraform-cli/src/tests/features/terraform-output/terraform-output.feature
@@ -9,11 +9,16 @@ Feature: terraform output
         When the terraform cli task is run
         Then the terraform cli task executed command "terraform output -json"
         And the terraform cli task is successful
-        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0" as output
-        And pipeline variable "TF_OUT_SOME_BOOL" is set to "true" as output
-        And pipeline variable "TF_OUT_SOME_STRING" is set to "some-string-value" as output
-        And pipeline secret "TF_OUT_SOME_SECRET_STRING" is set to "some-secret-string-value" as output
-        And pipeline variable "TF_OUT_SOME_NUMBER" is set to "1" as output
+        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
+        And pipeline output "TERRAFORM_LAST_EXITCODE" is set to "0"
+        And pipeline variable "TF_OUT_SOME_BOOL" is set to "true"
+        And pipeline output "TF_OUT_SOME_BOOL" is set to "true"
+        And pipeline variable "TF_OUT_SOME_STRING" is set to "some-string-value"
+        And pipeline output "TF_OUT_SOME_STRING" is set to "some-string-value"
+        And pipeline secret "TF_OUT_SOME_SECRET_STRING" is set to "some-secret-string-value"
+        And pipeline output secret "TF_OUT_SOME_SECRET_STRING" is set to "some-secret-string-value"
+        And pipeline variable "TF_OUT_SOME_NUMBER" is set to "1"
+        And pipeline output "TF_OUT_SOME_NUMBER" is set to "1"
         And the following warnings are logged
             | Currently only keys of type "string", "number", and "bool" will returned. The key "some_tuple" is not supported! |
             | Currently only keys of type "string", "number", and "bool" will returned. The key "some_map" is not supported!   |
@@ -30,8 +35,10 @@ Feature: terraform output
         When the terraform cli task is run
         Then the terraform cli task executed command "terraform output -json"
         And the terraform cli task is successful
-        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0" as output
+        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
+        And pipeline output "TERRAFORM_LAST_EXITCODE" is set to "0"
         And no pipeline variables starting with "TF_OUT" are set
+        And no pipeline outputs starting with "TF_OUT" are set
 
     Scenario: output with json flag defined
         Given terraform exists
@@ -39,8 +46,10 @@ Feature: terraform output
         And running command "terraform output -json -no-color" returns successful result with stdout from file "./src/tests/features/terraform-output/stdout_tf_output_string.json"
         When the terraform cli task is run
         Then the terraform cli task executed command "terraform output -json -no-color"
-        And the terraform cli task is successful
-        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0" as output
-        And pipeline variable "TF_OUT_SOME_STRING" is set to "some-string-value" as output
+        And the terraform cli task is successful        
+        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
+        And pipeline output "TERRAFORM_LAST_EXITCODE" is set to "0"
+        And pipeline variable "TF_OUT_SOME_STRING" is set to "some-string-value"
+        And pipeline output "TF_OUT_SOME_STRING" is set to "some-string-value"
         And the following info messages are logged
             | TF_OUT_SOME_STRING = some-string-value |

--- a/tasks/terraform-cli/src/tests/features/terraform-plan.feature
+++ b/tasks/terraform-cli/src/tests/features/terraform-plan.feature
@@ -9,7 +9,8 @@ Feature: terraform plan
         When the terraform cli task is run
         Then the terraform cli task executed command "terraform plan"
         And the terraform cli task is successful
-        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0" as output
+        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
+        And pipeline output "TERRAFORM_LAST_EXITCODE" is set to "0"
 
     Scenario: plan with azurerm
         Given terraform exists
@@ -42,7 +43,8 @@ Feature: terraform plan
             | -u servicePrincipal1      |
             | -p servicePrincipalKey123 |
         And the terraform cli task is successful
-        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0" as output
+        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
+        And pipeline output "TERRAFORM_LAST_EXITCODE" is set to "0"
 
     Scenario: plan with azurerm and command options
         Given terraform exists
@@ -75,7 +77,8 @@ Feature: terraform plan
             | -u servicePrincipal1      |
             | -p servicePrincipalKey123 |
         And the terraform cli task is successful
-        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0" as output
+        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
+        And pipeline output "TERRAFORM_LAST_EXITCODE" is set to "0"
 
     Scenario: plan with azurerm and var file in command options
         Given terraform exists
@@ -95,7 +98,8 @@ Feature: terraform plan
             | ARM_CLIENT_ID       | servicePrincipal1      |
             | ARM_CLIENT_SECRET   | servicePrincipalKey123 |
         And the terraform cli task is successful
-        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0" as output
+        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
+        And pipeline output "TERRAFORM_LAST_EXITCODE" is set to "0"
 
     Scenario: plan with detailed exit code and changes present
         Given terraform exists
@@ -128,8 +132,10 @@ Feature: terraform plan
             | -u servicePrincipal1      |
             | -p servicePrincipalKey123 |
         And the terraform cli task is successful
-        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "2" as output
-        And pipeline variable "TERRAFORM_PLAN_HAS_CHANGES" is set to "true" as output
+        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "2"
+        And pipeline output "TERRAFORM_LAST_EXITCODE" is set to "2"
+        And pipeline variable "TERRAFORM_PLAN_HAS_CHANGES" is set to "true"
+        And pipeline output "TERRAFORM_PLAN_HAS_CHANGES" is set to "true"
 
     Scenario: plan with detailed exit code and no changes present
         Given terraform exists
@@ -162,8 +168,10 @@ Feature: terraform plan
             | -u servicePrincipal1      |
             | -p servicePrincipalKey123 |
         And the terraform cli task is successful
-        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0" as output
-        And pipeline variable "TERRAFORM_PLAN_HAS_CHANGES" is set to "false" as output
+        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
+        And pipeline output "TERRAFORM_LAST_EXITCODE" is set to "0"
+        And pipeline variable "TERRAFORM_PLAN_HAS_CHANGES" is set to "false"
+        And pipeline output "TERRAFORM_PLAN_HAS_CHANGES" is set to "false"
 
     Scenario: plan with secure var file
         Given terraform exists        
@@ -196,8 +204,9 @@ Feature: terraform plan
             | -t ten1                   |
             | -u servicePrincipal1      |
             | -p servicePrincipalKey123 |
-        And the terraform cli task is successful
-        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0" as output
+        And the terraform cli task is successful        
+        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
+        And pipeline output "TERRAFORM_LAST_EXITCODE" is set to "0"
 
     Scenario: plan with secure env file
         Given terraform exists        
@@ -233,8 +242,9 @@ Feature: terraform plan
             | -t ten1                   |
             | -u servicePrincipal1      |
             | -p servicePrincipalKey123 |
-        And the terraform cli task is successful
-        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0" as output
+        And the terraform cli task is successful        
+        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
+        And pipeline output "TERRAFORM_LAST_EXITCODE" is set to "0"
 
     Scenario: plan with invalid auth scheme
         Given terraform exists

--- a/tasks/terraform-cli/src/tests/features/terraform-show.feature
+++ b/tasks/terraform-cli/src/tests/features/terraform-show.feature
@@ -10,8 +10,10 @@ Feature: terraform show
         When the terraform cli task is run
         Then the terraform cli task executed command "terraform show -json show.tfstate"
         And the terraform cli task is successful
-        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0" as output
+        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
+        And pipeline output "TERRAFORM_LAST_EXITCODE" is set to "0"
         And pipeline variable "TERRAFORM_PLAN_HAS_DESTROY_CHANGES" is not set
+        And pipeline output "TERRAFORM_PLAN_HAS_DESTROY_CHANGES" is not set
 
         Scenario: show without plan or state file
         Given terraform exists
@@ -20,8 +22,10 @@ Feature: terraform show
         When the terraform cli task is run
         Then the terraform cli task executed command "terraform show -json"
         And the terraform cli task is successful
-        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0" as output
+        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
+        And pipeline output "TERRAFORM_LAST_EXITCODE" is set to "0"
         And pipeline variable "TERRAFORM_PLAN_HAS_DESTROY_CHANGES" is not set
+        And pipeline output "TERRAFORM_PLAN_HAS_DESTROY_CHANGES" is not set
 
         Scenario: show tf plan file with destroy operations
         Given terraform exists
@@ -31,8 +35,10 @@ Feature: terraform show
         When the terraform cli task is run
         Then the terraform cli task executed command "terraform show -json show.plan"
         And the terraform cli task is successful
-        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0" as output
-        And pipeline variable "TERRAFORM_PLAN_HAS_DESTROY_CHANGES" is set to "true" as output
+        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
+        And pipeline output "TERRAFORM_LAST_EXITCODE" is set to "0"
+        And pipeline variable "TERRAFORM_PLAN_HAS_DESTROY_CHANGES" is set to "true"
+        And pipeline output "TERRAFORM_PLAN_HAS_DESTROY_CHANGES" is set to "true"
 
         Scenario: show tf plan file without destroy operations
         Given terraform exists
@@ -42,8 +48,10 @@ Feature: terraform show
         When the terraform cli task is run
         Then the terraform cli task executed command "terraform show -json show.plan"
         And the terraform cli task is successful
-        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0" as output
-        And pipeline variable "TERRAFORM_PLAN_HAS_DESTROY_CHANGES" is set to "false" as output
+        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
+        And pipeline output "TERRAFORM_LAST_EXITCODE" is set to "0"
+        And pipeline variable "TERRAFORM_PLAN_HAS_DESTROY_CHANGES" is set to "false"
+        And pipeline output "TERRAFORM_PLAN_HAS_DESTROY_CHANGES" is set to "false"
 
         Scenario: show tf plan file with destroy and EOL characters
         Given terraform exists
@@ -53,8 +61,10 @@ Feature: terraform show
         When the terraform cli task is run
         Then the terraform cli task executed command "terraform show -json show.plan"
         And the terraform cli task is successful
-        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0" as output
-        And pipeline variable "TERRAFORM_PLAN_HAS_DESTROY_CHANGES" is set to "true" as output
+        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
+        And pipeline output "TERRAFORM_LAST_EXITCODE" is set to "0"
+        And pipeline variable "TERRAFORM_PLAN_HAS_DESTROY_CHANGES" is set to "true"
+        And pipeline output "TERRAFORM_PLAN_HAS_DESTROY_CHANGES" is set to "true"
 
         Scenario: show tf state file with secure env file
         Given terraform exists
@@ -68,8 +78,10 @@ Feature: terraform show
             | TF_VAR_region         | eastus |
             | TF_VAR_env-short-name | dev    |
         And the terraform cli task is successful
-        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0" as output
+        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
+        And pipeline output "TERRAFORM_LAST_EXITCODE" is set to "0"
         And pipeline variable "TERRAFORM_PLAN_HAS_DESTROY_CHANGES" is not set
+        And pipeline output "TERRAFORM_PLAN_HAS_DESTROY_CHANGES" is not set
 
         Scenario: show tf state file with secure var file
         Given terraform exists
@@ -79,8 +91,10 @@ Feature: terraform show
         And running command "terraform show -json show.tfstate" returns successful result with stdout from file "./src/tests/stdout_tf_show_tfstate_version_only.json"
         When the terraform cli task is run
         And the terraform cli task fails with message "terraform show command supports only env files, no tfvars are allowed during this stage."
-        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "1" as output
+        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "1"
+        And pipeline output "TERRAFORM_LAST_EXITCODE" is set to "1"
         And pipeline variable "TERRAFORM_PLAN_HAS_DESTROY_CHANGES" is not set
+        And pipeline output "TERRAFORM_PLAN_HAS_DESTROY_CHANGES" is not set
 
         Scenario: show tf plan file with output only
         Given terraform exists
@@ -90,5 +104,7 @@ Feature: terraform show
         When the terraform cli task is run
         Then the terraform cli task executed command "terraform show -json show.plan"
         And the terraform cli task is successful
-        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0" as output
-        And pipeline variable "TERRAFORM_PLAN_HAS_DESTROY_CHANGES" is set to "false" as output
+        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
+        And pipeline output "TERRAFORM_LAST_EXITCODE" is set to "0"
+        And pipeline variable "TERRAFORM_PLAN_HAS_DESTROY_CHANGES" is set to "false"
+        And pipeline output "TERRAFORM_PLAN_HAS_DESTROY_CHANGES" is set to "false"

--- a/tasks/terraform-cli/src/tests/steps/task-context.steps.ts
+++ b/tasks/terraform-cli/src/tests/steps/task-context.steps.ts
@@ -115,17 +115,14 @@ export class TaskContextSteps {
         }
     }
 
-    @then("pipeline variable {string} is set to {string} as output")
-    public pipelineVariableIsSetAsOutput(key: string, value: string){
-        const variable = this.ctx.variables[key];
-        expect(variable).to.not.be.undefined;
-        if(variable){
-            expect(variable.val.toString()).to.eq(value);
-            expect(variable.secret).to.satisfy((isSecret: boolean | undefined) => {
-                return !isSecret;
-            });
-            expect(variable.isOutput).to.be.true;
-        }
+    @then("pipeline output {string} is set to {string}")
+    public pipelineOutputIsSet(key: string, value: string){
+        const output = this.ctx.outputs[key];
+        expect(output).to.not.be.undefined;
+        expect(output.val.toString()).to.eq(value);
+        expect(output.secret).to.satisfy((isSecret: boolean | undefined) => {
+            return !isSecret;
+        });
     }
 
     @then("pipeline secret {string} is set to {string}")
@@ -140,17 +137,14 @@ export class TaskContextSteps {
         }
     }
 
-    @then("pipeline secret {string} is set to {string} as output")
-    public pipelineSecretIsSetAsOutput(key: string, value: string){
-        const variable = this.ctx.variables[key];
-        expect(variable).to.not.be.undefined;
-        if(variable){
-            expect(variable.val).to.eq(value);
-            expect(variable.secret).to.satisfy((isSecret: boolean | undefined) => {
-                return isSecret === true;
-            });
-            expect(variable.isOutput).to.be.true;
-        }
+    @then("pipeline output secret {string} is set to {string}")
+    public pipelineOutputSecretIsSet(key: string, value: string){
+        const output = this.ctx.outputs[key];
+        expect(output).to.not.be.undefined;
+        expect(output.val).to.eq(value);
+        expect(output.secret).to.satisfy((isSecret: boolean | undefined) => {
+            return isSecret === true;
+        });
     }
 
     @then("no pipeline variables starting with {string} are set")
@@ -161,10 +155,24 @@ export class TaskContextSteps {
         })
     }
 
+    @then("no pipeline outputs starting with {string} are set")
+    public noPipelineOutputsStartingWithAreSet(prefix: string){
+        const names = Object.keys(this.ctx.outputs);
+        names.forEach(name => {
+            expect(name).to.satisfy((n: string) => !n.startsWith(prefix));
+        })
+    }
+
     @then("pipeline variable {string} is not set")
     public pipelineVariableIsNotSet(key: string){
         const variable = this.ctx.variables[key];
         expect(variable).to.be.undefined;
+    }
+
+    @then("pipeline output {string} is not set")
+    public pipelineOutputIsNotSet(key: string){
+        const output = this.ctx.outputs[key];
+        expect(output).to.be.undefined;
     }
 
     @then("the resolved terraform version is")


### PR DESCRIPTION
This updates the calls to `setVariable` to set both as variable and output. This is intended to add backward compatibility for the output changes released with 0.6.24

Resolves #45 
Resolves #46

Still testing this in pipeline to ensure azure pipelines allows both to be set so opening as draft for now.