### PR TITLE
remove warning when no changes to infrax

### DIFF
--- a/tasks/terraform-cli/src/commands/tf-plan.ts
+++ b/tasks/terraform-cli/src/commands/tf-plan.ts
@@ -66,7 +66,7 @@ export class TerraformPlan implements ICommand {
             switch (result.exitCode) {
                 case terraformPlanOkNoChanges:
                     content = this.parsePlanOutput(result.stdout, planHasNoChangesRe, ctx.publishPlanResults);
-                    this.logger.warning(`Plan '${ctx.publishPlanResults}' has no changes. Infrastructure is up-to-date.`)
+                    console.log(`Plan '${ctx.publishPlanResults}' has no changes. Infrastructure is up-to-date.`)
                     break;
                 case terraformPlanOkHasChanges:
                     content = this.parsePlanOutput(result.stdout, planHasChangesRe, ctx.publishPlanResults)

--- a/tasks/terraform-cli/src/tests/features/publish-plan-results/publish-plan-results.feature
+++ b/tasks/terraform-cli/src/tests/features/publish-plan-results/publish-plan-results.feature
@@ -29,7 +29,7 @@ Feature: publish plan results
         |Plan 'test_deploy.tfplan' is going to create 0 resources.|
         |Plan 'test_deploy.tfplan' is going to update 0 resources.|
         |Plan 'test_deploy.tfplan' is going to destroy 0 resources.|
-        And the following warnings are logged
+        And the following info messages are logged
         |Plan 'test_deploy.tfplan' has no changes. Infrastructure is up-to-date.|
 
     Scenario: publish plan results not specified


### PR DESCRIPTION
Logging as info rather than warning to prevent breaking changes in pipelines

Resolves #43 