### PR TITLE
Fix bug that breaks azurerm backend on tf v1.1.x

### DIFF
--- a/tasks/terraform-cli/src/backends/azurerm.ts
+++ b/tasks/terraform-cli/src/backends/azurerm.ts
@@ -21,7 +21,7 @@ export default class AzureRMBackend implements ITerraformBackend {
         }
 
         //use the arm_* prefix config only for versions before 0.12.0
-        if(ctx.terraformVersionMinor && ctx.terraformVersionMinor < 12){
+        if(ctx.terraformVersionMajor === 0 && typeof(ctx.terraformVersionMinor) == 'number' && ctx.terraformVersionMinor < 12){
             backendConfig.arm_subscription_id = ctx.backendServiceArmSubscriptionId;
             backendConfig.arm_tenant_id = ctx.backendServiceArmTenantId;
             backendConfig.arm_client_id = ctx.backendServiceArmClientId;


### PR DESCRIPTION
To maintain compatibility with older versions of terraform, the azurerm
backend code checks the version of terraform in use, and modifies the
names of some backend config auth parameters. Unfortunately this check
is faulty, and it only works with current 1.x versions because hashicorp
haven't released a build with major _and_ minor numbers greater than 0.

This code updates this check to actually test the major build number,
and where testing equality it relies on type checks and strict equality
checking to ensure that we aren't treating numeric values as booleans.