### PR TITLE
publish using PAT without access to all orgs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,7 @@ tfplan
 *.tfplan
 
 .idea
+/tools/token-generator/AdoTokenGenerator/obj
+/tools/token-generator/AdoTokenGenerator/bin
+/tools/token-generator/.vs/AdoTokenGenerator
+/tools/token-generator/AdoTokenGenerator/Properties/PublishProfiles

--- a/pipelines/publish/poll_task_install.sh
+++ b/pipelines/publish/poll_task_install.sh
@@ -19,11 +19,7 @@ while getopts t:s:c:e:p: flag; do
     esac
 done
 
-if az extension show --name azure-devops --output none ; then
-  echo "azure-devops az extension installed"
-else
-  az extension add --name azure-devops
-fi
+sleep 30s
 
 echo "$token" | az devops login --org $service_url
 until $(az devops extension show --extension-id $extension_id --publisher-id $publisher_id | grep -q "$task_id")

--- a/pipelines/publish/poll_task_install.sh
+++ b/pipelines/publish/poll_task_install.sh
@@ -9,7 +9,7 @@ service_url=
 attempts=0
 max=25
 
-while getopts t:s:c: flag; do
+while getopts t:s:c:e:p: flag; do
     case "${flag}" in
         t) token="${OPTARG}";;
         s) service_url="${OPTARG}";;

--- a/pipelines/publish/publish_private.yml
+++ b/pipelines/publish/publish_private.yml
@@ -69,11 +69,11 @@ stages:
             name: wait_tasks_terraform_installer
             inputs:
               filePath: $(Build.SourcesDirectory)/pipelines/publish/poll_task_install.sh
-              arguments: -s $(ado_service_url) -t $(marketplace_access_token) -c 11645770-d18e-11e8-8f5b-1b8b62612b3b          
+              arguments: -s $(ado_service_url) -t $(organization_access_token) -c 11645770-d18e-11e8-8f5b-1b8b62612b3b          
           - task: Bash@3
             name: wait_tasks_terraform_cli
             inputs:
               filePath: $(terraform_extension_dir)/pipelines/publish/poll_task_install.sh
-              arguments: -s $(ado_service_url) -t $(marketplace_access_token) -c 721c3f90-d938-11e8-9d92-09d7594721b5
+              arguments: -s $(ado_service_url) -t $(organization_access_token) -c 721c3f90-d938-11e8-9d92-09d7594721b5
 
               

--- a/pipelines/publish/publish_private.yml
+++ b/pipelines/publish/publish_private.yml
@@ -50,7 +50,7 @@ stages:
             name: publish
             inputs:
               connectTo: 'VsTeam'
-              connectedServiceName: 'marketplace_charleszipp'
+              connectedServiceName: 'marketplace_charleszipp_publish'
               cwd: $(terraform_extension_dir)
               extensionVersion: $(GitVersion.Major).$(GitVersion.Minor).$(GitVersion.Patch)            
               shareWith: $(marketplace_share_with)
@@ -61,7 +61,7 @@ stages:
             name: install
             inputs:
               connectTo: 'VsTeam'
-              connectedServiceName: 'marketplace_charleszipp'
+              connectedServiceName: 'azure-pipelines-terraform-beta-extensions'
               publisherId: $(marketplace_publisher)
               extensionId: azure-pipelines-tasks-terraform-${{ parameters.stage }}
               accounts: $(ado_service_url)

--- a/pipelines/publish/publish_private.yml
+++ b/pipelines/publish/publish_private.yml
@@ -69,11 +69,11 @@ stages:
             name: wait_tasks_terraform_installer
             inputs:
               filePath: $(Build.SourcesDirectory)/pipelines/publish/poll_task_install.sh
-              arguments: -s $(ado_service_url) -t $(organization_access_token) -c 11645770-d18e-11e8-8f5b-1b8b62612b3b          
+              arguments: -s $(ado_service_url) -t $(organization_access_token) -c 11645770-d18e-11e8-8f5b-1b8b62612b3b -e azure-pipelines-tasks-terraform-${{ parameters.stage }} -p $(marketplace_publisher)
           - task: Bash@3
             name: wait_tasks_terraform_cli
             inputs:
               filePath: $(terraform_extension_dir)/pipelines/publish/poll_task_install.sh
-              arguments: -s $(ado_service_url) -t $(organization_access_token) -c 721c3f90-d938-11e8-9d92-09d7594721b5
+              arguments: -s $(ado_service_url) -t $(organization_access_token) -c 721c3f90-d938-11e8-9d92-09d7594721b5 -e azure-pipelines-tasks-terraform-${{ parameters.stage }} -p $(marketplace_publisher)
 
               

--- a/pipelines/publish/publish_public.yml
+++ b/pipelines/publish/publish_public.yml
@@ -46,7 +46,7 @@ stages:
             name: publish
             inputs:
               connectTo: 'VsTeam'
-              connectedServiceName: 'marketplace_charleszipp'
+              connectedServiceName: 'marketplace_charleszipp_publish'
               cwd: $(terraform_extension_dir)
               extensionVersion: $(GitVersion.Major).$(GitVersion.Minor).$(GitVersion.Patch)            
               patternManifest: |

--- a/tools/token-generator/AdoTokenGenerator.sln
+++ b/tools/token-generator/AdoTokenGenerator.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31112.23
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AdoTokenGenerator", "AdoTokenGenerator\AdoTokenGenerator.csproj", "{1BEEA193-E09A-4D99-976E-920338EE608D}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{1BEEA193-E09A-4D99-976E-920338EE608D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1BEEA193-E09A-4D99-976E-920338EE608D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1BEEA193-E09A-4D99-976E-920338EE608D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1BEEA193-E09A-4D99-976E-920338EE608D}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C3A50427-F9D0-4C26-93FE-7EC552FA1F30}
+	EndGlobalSection
+EndGlobal

--- a/tools/token-generator/AdoTokenGenerator/AdoTokenGenerator.csproj
+++ b/tools/token-generator/AdoTokenGenerator/AdoTokenGenerator.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net48</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.8.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="16.170.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Services.InteractiveClient" Version="16.170.0" />
+  </ItemGroup>
+
+</Project>

--- a/tools/token-generator/AdoTokenGenerator/AdoTokenGenerator.csproj.user
+++ b/tools/token-generator/AdoTokenGenerator/AdoTokenGenerator.csproj.user
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <_LastSelectedProfileId>C:\code\_cz\azure-pipelines-tasks-terraform\tools\token-generator\AdoTokenGenerator\Properties\PublishProfiles\FolderProfile.pubxml</_LastSelectedProfileId>
+  </PropertyGroup>
+</Project>

--- a/tools/token-generator/AdoTokenGenerator/Commands/CreateToken.cs
+++ b/tools/token-generator/AdoTokenGenerator/Commands/CreateToken.cs
@@ -1,0 +1,21 @@
+﻿using CommandLine;
+using System;
+
+namespace AdoTokenGenerator.Commands
+{
+    [Verb("create", HelpText = "Create's a new personal access token")]
+    public class CreateToken
+    {
+        [Option('u')] 
+        public string TeamCollectionUri { get; set; }
+
+        [Option('o')] 
+        public Guid Organization { get; set; }
+        
+        [Option('n')] 
+        public string Name { get; set; }
+
+        [Option('e', Default = 90, HelpText = "Number of days until the token expires")]
+        public int Expiration { get; set; }
+    }
+}

--- a/tools/token-generator/AdoTokenGenerator/Commands/CreateTokenHandler.cs
+++ b/tools/token-generator/AdoTokenGenerator/Commands/CreateTokenHandler.cs
@@ -22,6 +22,7 @@ namespace AdoTokenGenerator.Commands
                 var token = new SessionToken()
                 {
                     TargetAccounts = new List<Guid>() { command.Organization },
+                    // Scopes documented here: https://docs.microsoft.com/en-us/azure/devops/integrate/get-started/authentication/oauth?view=azure-devops#scopes
                     Scope = "vso.gallery_publish vso.gallery_acquire vso.extension_manage",
                     DisplayName = command.Name,
                     ValidTo = DateTime.Now.AddDays(command.Expiration)

--- a/tools/token-generator/AdoTokenGenerator/Commands/CreateTokenHandler.cs
+++ b/tools/token-generator/AdoTokenGenerator/Commands/CreateTokenHandler.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.VisualStudio.Services.Client;
+using Microsoft.VisualStudio.Services.DelegatedAuthorization;
+using Microsoft.VisualStudio.Services.DelegatedAuthorization.WebApi;
+using Microsoft.VisualStudio.Services.WebApi;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AdoTokenGenerator.Commands
+{
+    public class CreateTokenHandler
+    {
+        public async Task<CreateTokenResult> ExecuteAsync(CreateToken command, CancellationToken cancellationToken)
+        {
+            Console.WriteLine($"Connecting to organization {command.TeamCollectionUri}");
+            using(var connection = new VssConnection(new Uri(command.TeamCollectionUri), new VssClientCredentials(false)))
+            {
+                await connection.ConnectAsync(cancellationToken);
+                Console.WriteLine($"Connected to organization {command.TeamCollectionUri}");
+                var tokenClient = connection.GetClient<TokenHttpClient>();
+                var token = new SessionToken()
+                {
+                    TargetAccounts = new List<Guid>() { command.Organization },
+                    Scope = "vso.gallery_publish vso.gallery_acquire vso.extension_manage",
+                    DisplayName = command.Name,
+                    ValidTo = DateTime.Now.AddDays(command.Expiration)
+                };
+                Console.WriteLine($"Creating marketplace token \"{command.Name}\"");
+                var result = await tokenClient.CreateSessionTokenAsync(token, SessionTokenType.Compact, false, cancellationToken: cancellationToken);
+                Console.WriteLine($"TOKEN CREATED: {result.Token}");
+                return new CreateTokenResult(result.Token);
+            }
+        }
+    }
+}

--- a/tools/token-generator/AdoTokenGenerator/Commands/CreateTokenHandler.cs
+++ b/tools/token-generator/AdoTokenGenerator/Commands/CreateTokenHandler.cs
@@ -23,7 +23,7 @@ namespace AdoTokenGenerator.Commands
                 {
                     TargetAccounts = new List<Guid>() { command.Organization },
                     // Scopes documented here: https://docs.microsoft.com/en-us/azure/devops/integrate/get-started/authentication/oauth?view=azure-devops#scopes
-                    Scope = "vso.gallery_publish vso.gallery_acquire vso.extension_manage",
+                    Scope = "vso.gallery_publish",
                     DisplayName = command.Name,
                     ValidTo = DateTime.Now.AddDays(command.Expiration)
                 };

--- a/tools/token-generator/AdoTokenGenerator/Commands/CreateTokenResult.cs
+++ b/tools/token-generator/AdoTokenGenerator/Commands/CreateTokenResult.cs
@@ -1,0 +1,12 @@
+﻿namespace AdoTokenGenerator.Commands
+{
+    public class CreateTokenResult
+    {
+        public CreateTokenResult(string token)
+        {
+            Token = token;
+        }
+
+        public string Token { get; }
+    }
+}

--- a/tools/token-generator/AdoTokenGenerator/Program.cs
+++ b/tools/token-generator/AdoTokenGenerator/Program.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.VisualStudio.Services.Client;
+using Microsoft.VisualStudio.Services.WebApi;
+using System;
+using CommandLine;
+using AdoTokenGenerator.Commands;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AdoTokenGenerator
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            MainAsync(args).Wait();
+        }
+
+        static async Task MainAsync(string[] args)
+        {
+            var container = new
+            {
+                CreateToken = new CreateTokenHandler(),
+                CancellationTokenSource = new CancellationTokenSource()
+            };
+
+            await Parser.Default.ParseArguments<CreateToken>(args)
+                .WithParsedAsync<CreateToken>(command => container.CreateToken.ExecuteAsync(command, container.CancellationTokenSource.Token));
+        }
+    }
+}

--- a/tools/token-generator/AdoTokenGenerator/Properties/launchSettings.json
+++ b/tools/token-generator/AdoTokenGenerator/Properties/launchSettings.json
@@ -1,0 +1,7 @@
+{
+  "profiles": {
+    "AdoTokenGenerator": {
+      "commandName": "Project"
+    }
+  }
+}


### PR DESCRIPTION
enables the ci/cd pipeline to unpublish, publish, share, and install using PAT's that have access to specific organizations (as opposed to All Accessible Organizations). 

- Adds a cli that allows to generate marketplace PAT for specific org
- Updates the pipeline to use different service connections for publishing and install activities. These activities need to target different organizations and therefore require different PAT's