### PR TITLE
reverting dependabot updates

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+	"name": " Codespace",
+	"image": "mcr.microsoft.com/vscode/devcontainers/javascript-node:0.202.3-16",
+	"settings": {
+		"workbench.colorTheme": "Default Dark+"
+	},
+	"extensions": [
+		"eamodio.gitlens",
+		"cschleiden.vscode-github-actions",
+		"redhat.vscode-yaml",
+		"bierner.markdown-preview-github-styles",
+		"coenraads.bracket-pair-colorizer",
+		"vscode-icons-team.vscode-icons",
+		"editorconfig.editorconfig",
+		"dbaeumer.vscode-eslint",
+		"ms-vscode.vscode-typescript-next",
+		"ecmel.vscode-html-css",
+		"streetsidesoftware.code-spell-checker",
+		"alexkrechik.cucumberautocomplete",
+		"4ops.terraform"
+	],
+	"postCreateCommand": "npm install -g typescript && npm install",
+}
+
+// Built with ❤ by [Pipeline Foundation](https://pipeline.foundation)

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,27 @@
+name: CodeQL Analysis
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 8 * * *'
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          queries: security-and-quality
+          languages: javascript
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1
+
+# Built with ❤ by [Pipeline Foundation](https://pipeline.foundation)

--- a/pipelines/pipeline-alpha.yml
+++ b/pipelines/pipeline-alpha.yml
@@ -13,6 +13,9 @@ variables:
   marketplace_publisher: charleszipp
   ado_service_url: https://dev.azure.com/azure-pipelines-terraform-alpha
 
+pool:
+  vmImage: ubuntu-latest
+
 name: $(GitVersion.FullSemVer)
 
 stages:

--- a/pipelines/publish/publish_private.yml
+++ b/pipelines/publish/publish_private.yml
@@ -61,7 +61,7 @@ stages:
             name: install
             inputs:
               connectTo: 'VsTeam'
-              connectedServiceName: 'marketplace_charleszipp'
+              connectedServiceName: azure-pipelines-terraform-${{ parameters.stage }}
               publisherId: $(marketplace_publisher)
               extensionId: azure-pipelines-tasks-terraform-${{ parameters.stage }}
               accounts: $(ado_service_url)
@@ -69,11 +69,11 @@ stages:
             name: wait_tasks_terraform_installer
             inputs:
               filePath: $(Build.SourcesDirectory)/pipelines/publish/poll_task_install.sh
-              arguments: -s $(ado_service_url) -t $(marketplace_access_token) -c 11645770-d18e-11e8-8f5b-1b8b62612b3b          
+              arguments: -s $(ado_service_url) -t $(organization_access_token) -c 11645770-d18e-11e8-8f5b-1b8b62612b3b          
           - task: Bash@3
             name: wait_tasks_terraform_cli
             inputs:
               filePath: $(terraform_extension_dir)/pipelines/publish/poll_task_install.sh
-              arguments: -s $(ado_service_url) -t $(marketplace_access_token) -c 721c3f90-d938-11e8-9d92-09d7594721b5
+              arguments: -s $(ado_service_url) -t $(organization_access_token) -c 721c3f90-d938-11e8-9d92-09d7594721b5
 
               

--- a/pipelines/test/smoke_test.yml
+++ b/pipelines/test/smoke_test.yml
@@ -18,55 +18,55 @@ jobs:
       inputs:
         command: version
         workingDirectory: $(terraform_templates_dir)
-    - task: charleszipp.azure-pipelines-tasks-terraform-${{ parameters.stage }}.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
-      displayName: 'terraform init'
-      inputs:
-        command: init
-        workingDirectory: $(terraform_templates_dir)
-        backendType: azurerm
-        backendServiceArm: 'env_test'
-        ensureBackend: true
-        backendAzureRmResourceGroupName: rg-trfrm-${{ parameters.stage }}-eus-czp
-        backendAzureRmResourceGroupLocation: eastus
-        backendAzureRmStorageAccountName: sttrfrm${{ parameters.stage }}eusczp
-        backendAzureRmStorageAccountSku: Standard_RAGRS
-        backendAzureRmContainerName: azure-pipelines-terraform
-        backendAzureRmKey: test_1.tfstate
-    - task: charleszipp.azure-pipelines-tasks-terraform-${{ parameters.stage }}.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
-      displayName: 'terraform validate'
-      inputs:
-        workingDirectory: $(terraform_templates_dir)
-    - task: charleszipp.azure-pipelines-tasks-terraform-${{ parameters.stage }}.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
-      displayName: 'terraform plan'
-      inputs:
-        command: plan
-        workingDirectory: $(terraform_templates_dir)
-        environmentServiceName: 'env_test'
-        secureVarsFile: $(tf_variables_secure_file)
-        publishPlanResults: smoke_test_${{ parameters.stage }}
-        commandOptions: '-out=$(System.DefaultWorkingDirectory)/terraform.tfplan -detailed-exitcode'
-    - task: charleszipp.azure-pipelines-tasks-terraform-${{ parameters.stage }}.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
-      displayName: 'terraform apply'
-      inputs:
-        command: apply
-        workingDirectory: $(terraform_templates_dir)
-        environmentServiceName: 'env_test'
-        commandOptions: '$(System.DefaultWorkingDirectory)/terraform.tfplan'
-    - task: charleszipp.azure-pipelines-tasks-terraform-${{ parameters.stage }}.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
-      displayName: 'terraform output'
-      inputs:
-        command: output
-        workingDirectory: $(terraform_templates_dir)
-    - bash: |
-        echo 'some_string is $(TF_OUT_SOME_STRING)'
-        echo 'some_bool is $(TF_OUT_SOME_BOOL)'
-        echo 'some_number is $(TF_OUT_SOME_NUMBER)'
-        echo 'some_sensitive_string is $(TF_OUT_SOME_SENSITIVE_STRING)'
-      displayName: echo tf output vars
-    - task: TerraformCLI@0
-      displayName: 'terraform destroy'
-      inputs:
-        command: destroy
-        workingDirectory: $(terraform_templates_dir)
-        environmentServiceName: 'env_test'
-        secureVarsFile: $(tf_variables_secure_file)
+    # - task: charleszipp.azure-pipelines-tasks-terraform-${{ parameters.stage }}.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
+    #   displayName: 'terraform init'
+    #   inputs:
+    #     command: init
+    #     workingDirectory: $(terraform_templates_dir)
+    #     backendType: azurerm
+    #     backendServiceArm: 'env_test'
+    #     ensureBackend: true
+    #     backendAzureRmResourceGroupName: rg-trfrm-${{ parameters.stage }}-eus-czp
+    #     backendAzureRmResourceGroupLocation: eastus
+    #     backendAzureRmStorageAccountName: sttrfrm${{ parameters.stage }}eusczp
+    #     backendAzureRmStorageAccountSku: Standard_RAGRS
+    #     backendAzureRmContainerName: azure-pipelines-terraform
+    #     backendAzureRmKey: test_1.tfstate
+    # - task: charleszipp.azure-pipelines-tasks-terraform-${{ parameters.stage }}.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
+    #   displayName: 'terraform validate'
+    #   inputs:
+    #     workingDirectory: $(terraform_templates_dir)
+    # - task: charleszipp.azure-pipelines-tasks-terraform-${{ parameters.stage }}.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
+    #   displayName: 'terraform plan'
+    #   inputs:
+    #     command: plan
+    #     workingDirectory: $(terraform_templates_dir)
+    #     environmentServiceName: 'env_test'
+    #     secureVarsFile: $(tf_variables_secure_file)
+    #     publishPlanResults: smoke_test_${{ parameters.stage }}
+    #     commandOptions: '-out=$(System.DefaultWorkingDirectory)/terraform.tfplan -detailed-exitcode'
+    # - task: charleszipp.azure-pipelines-tasks-terraform-${{ parameters.stage }}.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
+    #   displayName: 'terraform apply'
+    #   inputs:
+    #     command: apply
+    #     workingDirectory: $(terraform_templates_dir)
+    #     environmentServiceName: 'env_test'
+    #     commandOptions: '$(System.DefaultWorkingDirectory)/terraform.tfplan'
+    # - task: charleszipp.azure-pipelines-tasks-terraform-${{ parameters.stage }}.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
+    #   displayName: 'terraform output'
+    #   inputs:
+    #     command: output
+    #     workingDirectory: $(terraform_templates_dir)
+    # - bash: |
+    #     echo 'some_string is $(TF_OUT_SOME_STRING)'
+    #     echo 'some_bool is $(TF_OUT_SOME_BOOL)'
+    #     echo 'some_number is $(TF_OUT_SOME_NUMBER)'
+    #     echo 'some_sensitive_string is $(TF_OUT_SOME_SENSITIVE_STRING)'
+    #   displayName: echo tf output vars
+    # - task: TerraformCLI@0
+    #   displayName: 'terraform destroy'
+    #   inputs:
+    #     command: destroy
+    #     workingDirectory: $(terraform_templates_dir)
+    #     environmentServiceName: 'env_test'
+    #     secureVarsFile: $(tf_variables_secure_file)

--- a/pipelines/test/smoke_test.yml
+++ b/pipelines/test/smoke_test.yml
@@ -18,55 +18,55 @@ jobs:
       inputs:
         command: version
         workingDirectory: $(terraform_templates_dir)
-    # - task: charleszipp.azure-pipelines-tasks-terraform-${{ parameters.stage }}.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
-    #   displayName: 'terraform init'
-    #   inputs:
-    #     command: init
-    #     workingDirectory: $(terraform_templates_dir)
-    #     backendType: azurerm
-    #     backendServiceArm: 'env_test'
-    #     ensureBackend: true
-    #     backendAzureRmResourceGroupName: rg-trfrm-${{ parameters.stage }}-eus-czp
-    #     backendAzureRmResourceGroupLocation: eastus
-    #     backendAzureRmStorageAccountName: sttrfrm${{ parameters.stage }}eusczp
-    #     backendAzureRmStorageAccountSku: Standard_RAGRS
-    #     backendAzureRmContainerName: azure-pipelines-terraform
-    #     backendAzureRmKey: test_1.tfstate
-    # - task: charleszipp.azure-pipelines-tasks-terraform-${{ parameters.stage }}.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
-    #   displayName: 'terraform validate'
-    #   inputs:
-    #     workingDirectory: $(terraform_templates_dir)
-    # - task: charleszipp.azure-pipelines-tasks-terraform-${{ parameters.stage }}.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
-    #   displayName: 'terraform plan'
-    #   inputs:
-    #     command: plan
-    #     workingDirectory: $(terraform_templates_dir)
-    #     environmentServiceName: 'env_test'
-    #     secureVarsFile: $(tf_variables_secure_file)
-    #     publishPlanResults: smoke_test_${{ parameters.stage }}
-    #     commandOptions: '-out=$(System.DefaultWorkingDirectory)/terraform.tfplan -detailed-exitcode'
-    # - task: charleszipp.azure-pipelines-tasks-terraform-${{ parameters.stage }}.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
-    #   displayName: 'terraform apply'
-    #   inputs:
-    #     command: apply
-    #     workingDirectory: $(terraform_templates_dir)
-    #     environmentServiceName: 'env_test'
-    #     commandOptions: '$(System.DefaultWorkingDirectory)/terraform.tfplan'
-    # - task: charleszipp.azure-pipelines-tasks-terraform-${{ parameters.stage }}.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
-    #   displayName: 'terraform output'
-    #   inputs:
-    #     command: output
-    #     workingDirectory: $(terraform_templates_dir)
-    # - bash: |
-    #     echo 'some_string is $(TF_OUT_SOME_STRING)'
-    #     echo 'some_bool is $(TF_OUT_SOME_BOOL)'
-    #     echo 'some_number is $(TF_OUT_SOME_NUMBER)'
-    #     echo 'some_sensitive_string is $(TF_OUT_SOME_SENSITIVE_STRING)'
-    #   displayName: echo tf output vars
-    # - task: TerraformCLI@0
-    #   displayName: 'terraform destroy'
-    #   inputs:
-    #     command: destroy
-    #     workingDirectory: $(terraform_templates_dir)
-    #     environmentServiceName: 'env_test'
-    #     secureVarsFile: $(tf_variables_secure_file)
+    - task: charleszipp.azure-pipelines-tasks-terraform-${{ parameters.stage }}.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
+      displayName: 'terraform init'
+      inputs:
+        command: init
+        workingDirectory: $(terraform_templates_dir)
+        backendType: azurerm
+        backendServiceArm: 'env_test'
+        ensureBackend: true
+        backendAzureRmResourceGroupName: rg-trfrm-${{ parameters.stage }}-eus-czp
+        backendAzureRmResourceGroupLocation: eastus
+        backendAzureRmStorageAccountName: sttrfrm${{ parameters.stage }}eusczp
+        backendAzureRmStorageAccountSku: Standard_RAGRS
+        backendAzureRmContainerName: azure-pipelines-terraform
+        backendAzureRmKey: test_1.tfstate
+    - task: charleszipp.azure-pipelines-tasks-terraform-${{ parameters.stage }}.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
+      displayName: 'terraform validate'
+      inputs:
+        workingDirectory: $(terraform_templates_dir)
+    - task: charleszipp.azure-pipelines-tasks-terraform-${{ parameters.stage }}.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
+      displayName: 'terraform plan'
+      inputs:
+        command: plan
+        workingDirectory: $(terraform_templates_dir)
+        environmentServiceName: 'env_test'
+        secureVarsFile: $(tf_variables_secure_file)
+        publishPlanResults: smoke_test_${{ parameters.stage }}
+        commandOptions: '-out=$(System.DefaultWorkingDirectory)/terraform.tfplan -detailed-exitcode'
+    - task: charleszipp.azure-pipelines-tasks-terraform-${{ parameters.stage }}.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
+      displayName: 'terraform apply'
+      inputs:
+        command: apply
+        workingDirectory: $(terraform_templates_dir)
+        environmentServiceName: 'env_test'
+        commandOptions: '$(System.DefaultWorkingDirectory)/terraform.tfplan'
+    - task: charleszipp.azure-pipelines-tasks-terraform-${{ parameters.stage }}.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
+      displayName: 'terraform output'
+      inputs:
+        command: output
+        workingDirectory: $(terraform_templates_dir)
+    - bash: |
+        echo 'some_string is $(TF_OUT_SOME_STRING)'
+        echo 'some_bool is $(TF_OUT_SOME_BOOL)'
+        echo 'some_number is $(TF_OUT_SOME_NUMBER)'
+        echo 'some_sensitive_string is $(TF_OUT_SOME_SENSITIVE_STRING)'
+      displayName: echo tf output vars
+    - task: TerraformCLI@0
+      displayName: 'terraform destroy'
+      inputs:
+        command: destroy
+        workingDirectory: $(terraform_templates_dir)
+        environmentServiceName: 'env_test'
+        secureVarsFile: $(tf_variables_secure_file)


### PR DESCRIPTION
The dependabot updates appear to have broken what was being accumulated for 0.6.28. ADO is unable to run the terraform cli extension. Reverting the dependabot commits appears to have resolved the issue