### PR TITLE
[enh] Add flag to not mark workspace new command as failed if workspace already exists

### DIFF
--- a/pipelines/test/switch_workspaces.yml
+++ b/pipelines/test/switch_workspaces.yml
@@ -35,6 +35,14 @@ jobs:
         workspaceSubCommand: new
         workspaceName: foo
     - task: charleszipp.azure-pipelines-tasks-terraform-${{ parameters.stage }}.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
+      displayName: new workspace foo skip existing
+      inputs:
+        workingDirectory: $(terraform_templates_dir)
+        command: workspace
+        workspaceSubCommand: new
+        workspaceName: foo
+        skipExistingWorkspace: true
+    - task: charleszipp.azure-pipelines-tasks-terraform-${{ parameters.stage }}.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
       displayName: select workspace default
       inputs:
         workingDirectory: $(terraform_templates_dir)

--- a/tasks/terraform-cli/src/commands/tf-workspace-new.ts
+++ b/tasks/terraform-cli/src/commands/tf-workspace-new.ts
@@ -23,7 +23,7 @@ export class TerraformWorkspaceNew implements ICommand {
         return new CommandResponse(
             skipExistingWorkspace ? CommandStatus.Success : command_result.status,
             command_result.message,
-            skipExistingWorkspace ? 1 : command_result.lastExitCode,
+            skipExistingWorkspace ? 0 : command_result.lastExitCode,
         );
     }
 }

--- a/tasks/terraform-cli/src/commands/tf-workspace-new.ts
+++ b/tasks/terraform-cli/src/commands/tf-workspace-new.ts
@@ -1,4 +1,4 @@
-import { CommandResponse, ICommand } from ".";
+import {CommandResponse, CommandStatus, ICommand} from ".";
 import { ITaskContext } from "../context";
 import { IRunner } from "../runners";
 import { RunWithTerraform } from "../runners/builders";
@@ -17,6 +17,13 @@ export class TerraformWorkspaceNew implements ICommand {
 
         const result = await this.runner.exec(options);
 
-        return result.toCommandResponse();
+
+        const command_result = result.toCommandResponse();
+        const skipExistingWorkspace = ctx.skipExistingWorkspace && command_result.message && command_result.message.indexOf("already exists") >= 0;
+        return new CommandResponse(
+            skipExistingWorkspace ? CommandStatus.Success : command_result.status,
+            command_result.message,
+            skipExistingWorkspace ? 1 : command_result.lastExitCode,
+        );
     }
 }

--- a/tasks/terraform-cli/src/context/azdo-task-context.ts
+++ b/tasks/terraform-cli/src/context/azdo-task-context.ts
@@ -133,6 +133,9 @@ export default class AzdoTaskContext implements ITaskContext {
     get workspaceName() {
         return this.getInput("workspaceName", true);
     }
+    get skipExistingWorkspace() {
+        return this.getBoolInput("skipExistingWorkspace", false )
+    }
     finished() {
         this.finishedAt = process.hrtime(this.startedAt);
         this.runTime = this.finishedAt[1] / 1000000;

--- a/tasks/terraform-cli/src/context/index.ts
+++ b/tasks/terraform-cli/src/context/index.ts
@@ -42,6 +42,7 @@ export interface ITaskContext {
     terraformVersionMinor?: number;
     terraformVersionPatch?: number;
     setTerraformVersion: (full: string, major: number, minor: number, patch: number) => void;
+    skipExistingWorkspace?: boolean;
 }
 
 export { default as AzdoTaskContext } from './azdo-task-context';

--- a/tasks/terraform-cli/src/context/mock-task-context.ts
+++ b/tasks/terraform-cli/src/context/mock-task-context.ts
@@ -44,6 +44,7 @@ export default class MockTaskContext implements ITaskContext {
     terraformVersionMajor?: number;
     terraformVersionMinor?: number;
     terraformVersionPatch?: number;
+    skipExistingWorkspace?: boolean = false;
 
     constructor() {
         this.startedAt = process.hrtime();

--- a/tasks/terraform-cli/src/tests/features/workspace/stdout-new-workspace-bar-skipExisting.txt
+++ b/tasks/terraform-cli/src/tests/features/workspace/stdout-new-workspace-bar-skipExisting.txt
@@ -1,0 +1,1 @@
+\u001b[31mWorkspace \"bar\" already exists\u001b[0m\u001b[0m\n

--- a/tasks/terraform-cli/src/tests/features/workspace/terraform-workspace-new.feature
+++ b/tasks/terraform-cli/src/tests/features/workspace/terraform-workspace-new.feature
@@ -28,3 +28,12 @@ Feature: terraform workspace new
     When the terraform cli task is run
     Then the terraform cli task executed command "terraform workspace new bar"
     And the terraform cli task fails with message "\u001b[31mWorkspace \"bar\" already exists\u001b[0m\u001b[0m\n"
+
+    Scenario: new workspace already exists but it's allowed
+    Given terraform exists
+    And terraform command is "workspace"
+    And workspace command is "new" with name "bar" and command is set to succeed if existing
+    And running command "terraform workspace new bar" returns successful result with stdout from file "./src/tests/features/workspace/stdout-new-workspace-bar-skipExisting.txt"
+    When the terraform cli task is run
+    Then the terraform cli task executed command "terraform workspace new bar"
+        And the terraform cli task is successful

--- a/tasks/terraform-cli/src/tests/steps/task-context.steps.ts
+++ b/tasks/terraform-cli/src/tests/steps/task-context.steps.ts
@@ -103,6 +103,13 @@ export class TaskContextSteps {
         this.ctx.workspaceName = name;
     }
 
+    @given("workspace command is {string} with name {string} and command is set to succeed if existing")
+    public workspaceCommandIsForNameWithSkipExisting(subCommand: string, name: string){
+        this.ctx.workspaceSubCommand = subCommand;
+        this.ctx.workspaceName = name;
+        this.ctx.skipExistingWorkspace = true;
+    }
+
     @then("pipeline variable {string} is set to {string}")
     public pipelineVariableIsSet(key: string, value: string){
         const variable = this.ctx.variables[key];

--- a/tasks/terraform-cli/task.json
+++ b/tasks/terraform-cli/task.json
@@ -278,6 +278,15 @@
             "required": false,
             "visibleRule": "workspaceSubCommand = select",
             "helpMarkDown": "The name of the target workspace"
+        },
+        {
+            "name": "skipExistingWorkspace",
+            "type": "boolean",
+            "label": "Skip Create If Exists",
+            "defaultValue": "false",
+            "required": false,
+            "helpMarkDown": "Skip attempting to create existing workspaces",
+            "visibleRule": "workspaceSubCommand = new"
         }
     ],
     "execution": {


### PR DESCRIPTION
In our current CICD Pipeline, we are using the new workspace command and without this, we are only able to have our build mark as "Partially Succeed".

This would allows us to not have the step fails