### PR TITLE
adds workspace new option for classic ui

### DIFF
--- a/tasks/terraform-cli/task.json
+++ b/tasks/terraform-cli/task.json
@@ -116,7 +116,8 @@
             "required": false,
             "helpMarkDown": "The workspace sub-command to run.",
             "options": {
-                "select": "select"
+                "select": "select",
+                "new": "new"
             },
             "properties": {
                 "EditableOptions": "False"


### PR DESCRIPTION
The `new` workspace sub command was not added as an option to the `workspaceSubCommand` pickList. This was preventing the `new` sub command from being selectable from the classic ui editor.

![image](https://user-images.githubusercontent.com/4292559/141130602-a22064be-3d43-441f-b2e2-eda12bbceec1.png)

Related #12 