### PR TITLE
aws self-configured pipeline test & example

### DIFF
--- a/overview.md
+++ b/overview.md
@@ -80,6 +80,10 @@ When executing commands that interact with Azure such as `plan`, `apply`, and `d
         environmentServiceName: 'My Azure Service Connection'
 ```
 
+### Configuring Other Cloud Providers
+
+Other cloud providers such as **Amazon Web Services (AWS)** and **Google Cloud (GCP)** can be configured using [secure env files](#secure-env-files). See [`aws_self_configured.yml`](https://github.com/charleszipp/azure-pipelines-tasks-terraform/blob/main/pipelines/test/aws_self_configured.yml) for example.
+
 ### Execute Azure CLI From Local-Exec Provisioner
 
 When an azure service connection is provided and `runAzLogin` is set to `true`, the terraform cli task will run `az login` using the service connection credentials. This is intended to enable templates to execute az cli commands from a `local-exec` provisioner.

--- a/overview.md
+++ b/overview.md
@@ -147,6 +147,8 @@ The task currently supports the following backend configurations
 - azurerm - State is stored in a blob container within a specified Azure Storage Account.
 - self-configured - State configuration will be provided using environment variables or command options. Environment files can be provided using Secure Files Library in AzDO and specified in Secure Files configuration field. Command options such as `-backend-config=` flag can be provided in the Command Options configuration field.
 
+> NOTE: `self-configured` can be used to execute deployments for other cloud providers such as **Amazon Web Services (AWS)** & **Google Cloud (GCP)**. See [`aws_self_configured.yml`](https://github.com/charleszipp/azure-pipelines-tasks-terraform/blob/main/pipelines/test/aws_self_configured.yml) for example.
+
 If azurerm selected, the task will prompt for a service connection and storage account details to use for the backend.
 
 ```yaml

--- a/overview.md
+++ b/overview.md
@@ -82,7 +82,7 @@ When executing commands that interact with Azure such as `plan`, `apply`, and `d
 
 ### Configuring Other Cloud Providers
 
-Other cloud providers such as **Amazon Web Services (AWS)** and **Google Cloud (GCP)** can be configured using [secure env files](#secure-env-files). See [`aws_self_configured.yml`](https://github.com/charleszipp/azure-pipelines-tasks-terraform/blob/main/pipelines/test/aws_self_configured.yml) for example.
+Other cloud providers such as **Amazon Web Services (AWS)** and **Google Cloud (GCP)** can be configured using [secure env files](#secure-variable-secrets). See [`aws_self_configured.yml`](https://github.com/charleszipp/azure-pipelines-tasks-terraform/blob/main/pipelines/test/aws_self_configured.yml) for example.
 
 ### Execute Azure CLI From Local-Exec Provisioner
 
@@ -190,8 +190,22 @@ There are multiple methods to provide secrets within the vars provided to terraf
     inputs:
         command: plan
         environmentServiceName: 'My Azure Service Connection'
-        # guid for the secure file to use. Can be standard terraform vars file or .env file.
+        # guid of the secure file to use. Can be standard terraform vars file or .env file.
         secureVarsFile: 446e8878-994d-4069-ab56-5b302067a869
+        # specify a variable input via pipeline variable
+        commandOptions: '-var secret=$(mySecretPipelineVar)'
+```
+
+The name of the secure file can also be used.
+
+```yaml
+- task: TerraformCLI@0
+    displayName: 'terraform plan'
+    inputs:
+        command: plan
+        environmentServiceName: 'My Azure Service Connection'
+        # name of the secure file to use. Can be standard terraform vars file or .env file.
+        secureVarsFile: my-secure-file.env
         # specify a variable input via pipeline variable
         commandOptions: '-var secret=$(mySecretPipelineVar)'
 ```

--- a/pipelines/build/build.yml
+++ b/pipelines/build/build.yml
@@ -6,7 +6,7 @@ stages:
   variables:
     - group: build
   jobs:
-  # - template: build_version.yml
+  - template: build_version.yml
   # - template: build_terraform_installer.yml
   # - template: build_views_terraform_plan.yml
   # - template: build_terraform_cli.yml

--- a/pipelines/build/build.yml
+++ b/pipelines/build/build.yml
@@ -6,9 +6,9 @@ stages:
   variables:
     - group: build
   jobs:
-  - template: build_version.yml
-  - template: build_terraform_installer.yml
-  - template: build_views_terraform_plan.yml
-  - template: build_terraform_cli.yml
-  - template: build_terraform_extension.yml
+  # - template: build_version.yml
+  # - template: build_terraform_installer.yml
+  # - template: build_views_terraform_plan.yml
+  # - template: build_terraform_cli.yml
+  # - template: build_terraform_extension.yml
   - template: build_terraform_templates.yml

--- a/pipelines/build/build.yml
+++ b/pipelines/build/build.yml
@@ -7,8 +7,8 @@ stages:
     - group: build
   jobs:
   - template: build_version.yml
-  # - template: build_terraform_installer.yml
-  # - template: build_views_terraform_plan.yml
-  # - template: build_terraform_cli.yml
-  # - template: build_terraform_extension.yml
+  - template: build_terraform_installer.yml
+  - template: build_views_terraform_plan.yml
+  - template: build_terraform_cli.yml
+  - template: build_terraform_extension.yml
   - template: build_terraform_templates.yml

--- a/pipelines/pipeline-alpha.yml
+++ b/pipelines/pipeline-alpha.yml
@@ -19,9 +19,9 @@ pool:
 name: $(GitVersion.FullSemVer)
 
 stages:
-  # - template: build/build.yml
-  #   parameters:
-  #     stage: alpha
+  - template: build/build.yml
+    parameters:
+      stage: alpha
   # - template: publish/publish_private.yml
   #   parameters:
   #     stage: alpha

--- a/pipelines/pipeline-alpha.yml
+++ b/pipelines/pipeline-alpha.yml
@@ -29,5 +29,4 @@ stages:
     parameters:
       stage: alpha
       scenarios:
-        - smoke_test.yml
-        - switch_workspaces.yml
+        - aws_self_configured.yml

--- a/pipelines/pipeline-alpha.yml
+++ b/pipelines/pipeline-alpha.yml
@@ -22,11 +22,12 @@ stages:
   - template: build/build.yml
     parameters:
       stage: alpha
-  # - template: publish/publish_private.yml
-  #   parameters:
-  #     stage: alpha
+  - template: publish/publish_private.yml
+    parameters:
+      stage: alpha
   - template: test/test.yml
     parameters:
       stage: alpha
       scenarios:
+        - smoke_test.yml
         - aws_self_configured.yml

--- a/pipelines/pipeline-alpha.yml
+++ b/pipelines/pipeline-alpha.yml
@@ -19,12 +19,12 @@ pool:
 name: $(GitVersion.FullSemVer)
 
 stages:
-  - template: build/build.yml
-    parameters:
-      stage: alpha
-  - template: publish/publish_private.yml
-    parameters:
-      stage: alpha
+  # - template: build/build.yml
+  #   parameters:
+  #     stage: alpha
+  # - template: publish/publish_private.yml
+  #   parameters:
+  #     stage: alpha
   - template: test/test.yml
     parameters:
       stage: alpha

--- a/pipelines/pipeline-beta.yml
+++ b/pipelines/pipeline-beta.yml
@@ -53,6 +53,5 @@ stages:
         - local_exec_az_cli.yml
         - init_with_ensure_backend_no_storage_account.yml
         - init_with_self_configured_backend.yml
-        - switch_workspaces.yml        
-        # removing for now as it appears the compatible azurerm plugin is no longer available
-        # - init_with_version_11.yml
+        - switch_workspaces.yml  
+        - aws_self_configured.yml   

--- a/pipelines/pipeline-rc.yml
+++ b/pipelines/pipeline-rc.yml
@@ -55,5 +55,4 @@ stages:
         - init_with_ensure_backend_no_storage_account.yml
         - init_with_self_configured_backend.yml
         - switch_workspaces.yml
-        # removing for now as it appears the compatible azurerm plugin is no longer available
-        # - init_with_version_11.yml
+        - aws_self_configured.yml

--- a/pipelines/test/aws_self_configured.yml
+++ b/pipelines/test/aws_self_configured.yml
@@ -1,0 +1,23 @@
+parameters:
+  stage: ''
+
+jobs:
+- job: aws_self_configured_${{ parameters.stage }}
+  steps:
+    - task: DownloadPipelineArtifact@2
+      displayName: download terraform templates
+      inputs: 
+        artifact: terraform_templates
+        path: $(terraform_extension_dir)
+    - task: charleszipp.azure-pipelines-tasks-terraform-${{ parameters.stage }}.azure-pipelines-tasks-terraform-installer.TerraformInstaller@0
+      displayName: install terraform
+      inputs:
+        terraformVersion: 1.0.10
+    - task: charleszipp.azure-pipelines-tasks-terraform-${{ parameters.stage }}.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
+      displayName: 'terraform init'
+      inputs:
+        command: init
+        workingDirectory: $(terraform_templates_dir)
+        backendType: self-configured
+        commandOptions: -backend-config=bucket=s3-trfrm-${{ parameters.stage }}-eus-czp -backend-config=key=azure-pipelines-terraform/aws-self-config
+        secureVarsFile: self-configured-aws.env

--- a/pipelines/test/aws_self_configured.yml
+++ b/pipelines/test/aws_self_configured.yml
@@ -3,6 +3,8 @@ parameters:
 
 jobs:
 - job: aws_self_configured_${{ parameters.stage }}
+  variables: 
+    test_templates_dir: $(terraform_templates_dir)/aws
   steps:
     - task: DownloadPipelineArtifact@2
       displayName: download terraform templates
@@ -17,7 +19,7 @@ jobs:
       displayName: 'terraform init'
       inputs:
         command: init
-        workingDirectory: $(terraform_templates_dir)
+        workingDirectory: $(test_templates_dir)
         backendType: self-configured
         commandOptions: -backend-config=bucket=s3-trfrm-${{ parameters.stage }}-eus-czp -backend-config=key=azure-pipelines-terraform/aws-self-config
         secureVarsFile: self-configured-aws.env

--- a/pipelines/test/aws_self_configured.yml
+++ b/pipelines/test/aws_self_configured.yml
@@ -22,6 +22,9 @@ jobs:
         workingDirectory: $(test_templates_dir)
         backendType: self-configured
         commandOptions: -backend-config=bucket=s3-trfrm-${{ parameters.stage }}-eus-czp -backend-config=key=azure-pipelines-terraform/aws-self-config
+        # The secure env file contains the following vars
+        # AWS_DEFAULT_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
+        # see also https://www.terraform.io/docs/language/settings/backends/s3.html#configuration
         secureVarsFile: self-configured-aws.env
     - task: charleszipp.azure-pipelines-tasks-terraform-${{ parameters.stage }}.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
       displayName: 'terraform validate'

--- a/pipelines/test/aws_self_configured.yml
+++ b/pipelines/test/aws_self_configured.yml
@@ -23,3 +23,27 @@ jobs:
         backendType: self-configured
         commandOptions: -backend-config=bucket=s3-trfrm-${{ parameters.stage }}-eus-czp -backend-config=key=azure-pipelines-terraform/aws-self-config
         secureVarsFile: self-configured-aws.env
+    - task: charleszipp.azure-pipelines-tasks-terraform-${{ parameters.stage }}.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
+      displayName: 'terraform validate'
+      inputs:
+        workingDirectory: $(test_templates_dir)
+    - task: charleszipp.azure-pipelines-tasks-terraform-${{ parameters.stage }}.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
+      displayName: 'terraform plan'
+      inputs:
+        command: plan
+        workingDirectory: $(test_templates_dir)
+        secureVarsFile: self-configured-aws.env
+        commandOptions: '-out=$(System.DefaultWorkingDirectory)/terraform.tfplan'
+    - task: charleszipp.azure-pipelines-tasks-terraform-${{ parameters.stage }}.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
+      displayName: 'terraform apply'
+      inputs:
+        command: apply
+        workingDirectory: $(test_templates_dir)
+        secureVarsFile: self-configured-aws.env
+        commandOptions: '$(System.DefaultWorkingDirectory)/terraform.tfplan'
+    - task: charleszipp.azure-pipelines-tasks-terraform-${{ parameters.stage }}.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
+      displayName: 'terraform destroy'
+      inputs:
+        command: destroy
+        workingDirectory: $(test_templates_dir)
+        secureVarsFile: self-configured-aws.env

--- a/templates/aws/.terraform/.gitignore
+++ b/templates/aws/.terraform/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/templates/aws/main.tf
+++ b/templates/aws/main.tf
@@ -1,0 +1,12 @@
+terraform {
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+}
+
+resource "aws_s3_bucket" "s3b_test" {
+  bucket = "s3-test-eus-czp"
+  acl    = "private"
+}


### PR DESCRIPTION
Adds a test to demonstrate the tasks ability to support deployments to AWS via self-configured backend and provider. The pipeline uses a secure env file to establish AWS backend and provider credentials. It uses the -backend-config args to specify non-sensitive configuration options such as bucket name and key.

This is first step towards establishing more first-class support for AWS as it helps identify what configuration is needed to support deployment.

Resolves #174 
Resolves #177