### PR TITLE
update docs to set working directory for `terraform output`

### DIFF
--- a/overview.md
+++ b/overview.md
@@ -250,7 +250,12 @@ Pipeline configuration to run terraform `output` command
     displayName: 'terraform output'
     inputs:
         command: output
+        # ensure working directory targets same directory as apply step
+        # if not specified $(System.DefaultWorkingDirectory) will be used
+        # workingDirectory: $(my_terraform_templates_dir)
 ```
+
+> NOTE: `workingDirectory` must be set to the same working directory that is used to execute other operations such as `apply`. The default for `workingDirectory` is `$(System.DefaultWorkingDirectory)` when not specified.
 
 Use output variables as pipeline variables
 


### PR DESCRIPTION
Updates the documentation to more explicitly indicate that `workingDirectory` should be set to the same directory as `apply`. Also indicates what behavior is when it is not provided.

Resolves #214 