### PR TITLE
make azurerm backend configuration optional

### DIFF
--- a/pipelines/pipeline-beta.yml
+++ b/pipelines/pipeline-beta.yml
@@ -56,4 +56,4 @@ stages:
         - switch_workspaces.yml  
         - aws_self_configured.yml  
         - aws_service_connection.yml
-        - init_without_location.yml
+        - init_without_ensure_backend.yml

--- a/pipelines/pipeline-rc.yml
+++ b/pipelines/pipeline-rc.yml
@@ -57,4 +57,4 @@ stages:
         - switch_workspaces.yml
         - aws_self_configured.yml
         - aws_service_connection.yml
-        - init_without_location.yml
+        - init_without_ensure_backend.yml

--- a/pipelines/test/init_without_ensure_backend.yml
+++ b/pipelines/test/init_without_ensure_backend.yml
@@ -2,7 +2,7 @@ parameters:
   stage: ''
 
 jobs:
-- job: init_without_location_${{ parameters.stage }}
+- job: init_without_ensure_backend_${{ parameters.stage }}
   steps:
     - task: DownloadPipelineArtifact@2
       displayName: download terraform templates
@@ -22,6 +22,5 @@ jobs:
         backendServiceArm: 'env_test'
         backendAzureRmResourceGroupName: rg-trfrm-${{ parameters.stage }}-eus-czp
         backendAzureRmStorageAccountName: sttrfrm${{ parameters.stage }}eusczp
-        backendAzureRmStorageAccountSku: Standard_RAGRS
         backendAzureRmContainerName: azure-pipelines-terraform
-        backendAzureRmKey: init_without_location.tfstate
+        backendAzureRmKey: init_without_ensure_backend.tfstate

--- a/tasks/terraform-cli/src/backends/azurerm.ts
+++ b/tasks/terraform-cli/src/backends/azurerm.ts
@@ -39,7 +39,9 @@ export default class AzureRMBackend implements ITerraformBackend {
         };
 
         for (var config in backendConfig) {
-            result.args.push(`-backend-config=${config}=${backendConfig[config]}`);
+            if(backendConfig[config]){
+              result.args.push(`-backend-config=${config}=${backendConfig[config]}`);
+            }            
         }
 
         if (ctx.ensureBackend === true) {

--- a/tasks/terraform-cli/src/context/azdo-task-context.ts
+++ b/tasks/terraform-cli/src/context/azdo-task-context.ts
@@ -70,27 +70,27 @@ export default class AzdoTaskContext implements ITaskContext {
     }
     @trackValue("inputs.backends.azurerm.rg", usesBackend(BackendTypes.azurerm), true)
     get backendAzureRmResourceGroupName() {
-        return this.getInput("backendAzureRmResourceGroupName", true);
+        return this.getInput("backendAzureRmResourceGroupName");
     }
     @trackValue("inputs.backends.azurerm.rg.location", (ctx: ITaskContext) => isCommand("init") && ctx.backendType == BackendTypes.azurerm && ctx.ensureBackend === true)
     get backendAzureRmResourceGroupLocation() {
-        return this.getInput("backendAzureRmResourceGroupLocation", true);
+        return this.getInput("backendAzureRmResourceGroupLocation");
     }
     @trackValue("inputs.backends.azurerm.storage", usesBackend(BackendTypes.azurerm), true)
     get backendAzureRmStorageAccountName() {
-        return this.getInput("backendAzureRmStorageAccountName", true);
+        return this.getInput("backendAzureRmStorageAccountName");
     }
-    @trackValue("inputs.backends.azurerm.storage.sku", usesBackend(BackendTypes.azurerm))
+    @trackValue("inputs.backends.azurerm.storage.sku", (ctx: ITaskContext) => isCommand("init") && ctx.backendType == BackendTypes.azurerm && ctx.ensureBackend === true)
     get backendAzureRmStorageAccountSku() {
-        return this.getInput("backendAzureRmStorageAccountSku", true);
+        return this.getInput("backendAzureRmStorageAccountSku");
     }
     @trackValue("inputs.backends.azurerm.storage.container", usesBackend(BackendTypes.azurerm), true)
     get backendAzureRmContainerName() {
-        return this.getInput("backendAzureRmContainerName", true);
+        return this.getInput("backendAzureRmContainerName");
     }
     @trackValue("inputs.backends.azurerm.storage.key", usesBackend(BackendTypes.azurerm), true)
     get backendAzureRmKey() {
-        return this.getInput("backendAzureRmKey", true);
+        return this.getInput("backendAzureRmKey");
     }
     get backendServiceArmAuthorizationScheme() {
         return this.getEndpointAuthorizationScheme(this.backendServiceArm, true);


### PR DESCRIPTION
This makes the backend configuration for the azurerm storage account backend optional. This should resolve the bugs by causing the logging to ignore the values if not defined rather than triggering an error. Also updated the condition for SKU as a secondary measure to prevent logger from tracking it if ensureBackend is not enabled.

Resolves #15
Resolves #239 
Resolves #238