### PR TITLE
add support for google cloud storage backend

### DIFF
--- a/pipelines/pipeline-alpha.yml
+++ b/pipelines/pipeline-alpha.yml
@@ -30,4 +30,4 @@ stages:
       stage: alpha
       scenarios:
         - smoke_test.yml
-        - aws_service_connection.yml
+        - gcp_credential_file.yml

--- a/pipelines/pipeline-beta.yml
+++ b/pipelines/pipeline-beta.yml
@@ -57,3 +57,4 @@ stages:
         - aws_self_configured.yml  
         - aws_service_connection.yml
         - init_without_ensure_backend.yml
+        - gcp_credential_file.yml

--- a/pipelines/pipeline-rc.yml
+++ b/pipelines/pipeline-rc.yml
@@ -58,3 +58,4 @@ stages:
         - aws_self_configured.yml
         - aws_service_connection.yml
         - init_without_ensure_backend.yml
+        - gcp_credential_file.yml

--- a/pipelines/test/gcp_credential_file.yml
+++ b/pipelines/test/gcp_credential_file.yml
@@ -1,0 +1,26 @@
+parameters:
+  stage: ''
+
+jobs:
+- job: gcp_credential_file_${{ parameters.stage }}
+  variables: 
+    test_templates_dir: $(terraform_templates_dir)/gcp
+  steps:
+    - task: DownloadPipelineArtifact@2
+      displayName: download terraform templates
+      inputs: 
+        artifact: terraform_templates
+        path: $(terraform_extension_dir)
+    - task: charleszipp.azure-pipelines-tasks-terraform-${{ parameters.stage }}.azure-pipelines-tasks-terraform-installer.TerraformInstaller@0
+      displayName: install terraform
+      inputs:
+        terraformVersion: 1.0.10
+    - task: charleszipp.azure-pipelines-tasks-terraform-${{ parameters.stage }}.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
+      displayName: 'terraform init'
+      inputs:
+        command: init
+        workingDirectory: $(test_templates_dir)
+        backendType: gcs
+        backendGcsCredentials: gcs-backend-key.json
+        backendGcsBucket: gcs-trfrm-${{ parameters.stage }}-eus-czp
+        backendGcsPrefix: 'azure-pipelines-terraform/gcp_credential_file'

--- a/tasks/terraform-cli/src/backends/gcs.ts
+++ b/tasks/terraform-cli/src/backends/gcs.ts
@@ -1,0 +1,30 @@
+import { ITerraformBackend, TerraformBackendInitResult } from ".";
+import { ITaskContext } from "../context";
+import { ITaskAgent } from "../task-agent";
+
+export default class GcsBackend implements ITerraformBackend {
+  constructor(private readonly agent: ITaskAgent) {
+  }
+
+  async init(ctx: ITaskContext): Promise<TerraformBackendInitResult> {
+    const credentials = this.agent.downloadSecureFile(ctx.backendGcsCredentials);
+
+    let backendConfig: any = {
+      bucket: ctx.backendGcsBucket,
+      prefix: ctx.backendGcsPrefix,
+      credentials 
+    };
+
+    const result = <TerraformBackendInitResult>{
+      args: []
+    }
+
+    for(var config in backendConfig){
+      if(backendConfig[config]){
+        result.args.push(`-backend-config=${config}=${backendConfig[config]}`);
+      }
+    }
+
+    return Promise.resolve(result);
+  }
+}

--- a/tasks/terraform-cli/src/backends/gcs.ts
+++ b/tasks/terraform-cli/src/backends/gcs.ts
@@ -7,7 +7,7 @@ export default class GcsBackend implements ITerraformBackend {
   }
 
   async init(ctx: ITaskContext): Promise<TerraformBackendInitResult> {
-    const credentials = this.agent.downloadSecureFile(ctx.backendGcsCredentials);
+    const credentials = await this.agent.downloadSecureFile(ctx.backendGcsCredentials);
 
     let backendConfig: any = {
       bucket: ctx.backendGcsBucket,

--- a/tasks/terraform-cli/src/backends/index.ts
+++ b/tasks/terraform-cli/src/backends/index.ts
@@ -10,7 +10,8 @@ export enum BackendTypes{
     local = "local",
     azurerm = "azurerm",
     selfConfigured = "self-configured",
-    aws = "aws"
+    aws = "aws",
+    gcs = "gcs"
 }
 
 export { default as AzureRMBackend } from './azurerm';

--- a/tasks/terraform-cli/src/commands/tf-init.ts
+++ b/tasks/terraform-cli/src/commands/tf-init.ts
@@ -6,6 +6,7 @@ import { ITaskContext } from "../context";
 import { ITaskAgent } from "../task-agent";
 import AwsBackend from "../backends/aws";
 import { ILogger } from "../logger";
+import GcsBackend from "../backends/gcs";
 
 export class TerraformInit implements ICommand {
     private readonly runner: IRunner;    
@@ -26,6 +27,9 @@ export class TerraformInit implements ICommand {
               break;
             case BackendTypes.aws:
               backend = new AwsBackend();
+              break;
+            case BackendTypes.gcs:
+              backend = new GcsBackend(this.taskAgent);
               break;
         }
         return backend

--- a/tasks/terraform-cli/src/context/azdo-task-context.ts
+++ b/tasks/terraform-cli/src/context/azdo-task-context.ts
@@ -198,7 +198,19 @@ export default class AzdoTaskContext implements ITaskContext {
     @trackValue("inputs.providers.aws.region", usesProviderAws)
     get providerAwsRegion() {
       return this.getInput("providerAwsRegion", true);
-    }
+    }    
+    @trackValue("inputs.backends.gcs.credentials", usesBackend(BackendTypes.gcs), true)
+    get backendGcsCredentials(){
+      return this.getInput("backendGcsCredentials");
+    };
+    @trackValue("inputs.backends.gcs.bucket", usesBackend(BackendTypes.gcs), true)
+    get backendGcsBucket(){
+      return this.getInput("backendGcsBucket");
+    };
+    @trackValue("inputs.backends.gcs.prefix", usesBackend(BackendTypes.gcs), true)
+    get backendGcsPrefix(){
+      return this.getInput("backendGcsPrefix");
+    };
     finished() {
         this.finishedAt = process.hrtime(this.startedAt);
         this.runTime = this.finishedAt[1] / 1000000;

--- a/tasks/terraform-cli/src/context/index.ts
+++ b/tasks/terraform-cli/src/context/index.ts
@@ -55,6 +55,9 @@ export interface ITaskContext {
     providerServiceAwsAccessKey: string;
     providerServiceAwsSecretKey: string;
     providerAwsRegion: string;
+    backendGcsCredentials: string;
+    backendGcsBucket: string;
+    backendGcsPrefix: string;
 }
 
 export const TRACKED_CONTEXT_PROPERTIES_METADATA_KEY = Symbol("propLogMetadata");

--- a/tasks/terraform-cli/src/context/mock-task-context.ts
+++ b/tasks/terraform-cli/src/context/mock-task-context.ts
@@ -55,6 +55,9 @@ export default class MockTaskContext implements ITaskContext {
     providerServiceAwsAccessKey: string = "";
     providerServiceAwsSecretKey: string = "";
     providerAwsRegion: string = "";
+    backendGcsCredentials: string = "";
+    backendGcsBucket: string = "";
+    backendGcsPrefix: string = "";
 
     constructor() {
         this.startedAt = process.hrtime();

--- a/tasks/terraform-cli/src/tests/features/terraform-init-gcp.feature
+++ b/tasks/terraform-cli/src/tests/features/terraform-init-gcp.feature
@@ -1,0 +1,25 @@
+Feature: terraform init on gcp
+
+  terraform init [options for aws] [dir]
+
+  Scenario: init with gcs backend all parameters
+    Given terraform exists
+    And terraform command is "init"
+    And running command "terraform version" returns successful result with stdout "Terraform v1.0.11\non windows_amd64\n"
+    And gcs backend type selected with the following bucket
+      | bucket | gcstrfrmeusczp                   |
+      | prefix | azure-pipelines-terraform/infrax |
+    And gcs backend credential file specified with id "2ab84611-6012-46cf-921f-7f7fb7ee27cd" and name "./src/tests/gcp-fake-key.json"
+    And running command "terraform init" with the following options returns successful result
+      | option                                                   |
+      | -backend-config=bucket=gcstrfrmeusczp                    |
+      | -backend-config=prefix=azure-pipelines-terraform/infrax  |
+      | -backend-config=credentials=./src/tests/gcp-fake-key.json |
+    When the terraform cli task is run
+    Then terraform is initialized with the following options
+      | option                                                   |
+      | -backend-config=bucket=gcstrfrmeusczp                    |
+      | -backend-config=prefix=azure-pipelines-terraform/infrax  |
+      | -backend-config=credentials=./src/tests/gcp-fake-key.json |
+    And the terraform cli task is successful
+    And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"

--- a/tasks/terraform-cli/src/tests/gcp-fake-key.json
+++ b/tasks/terraform-cli/src/tests/gcp-fake-key.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "azure-pipelines-terraform",
+  "private_key_id": "foo",
+  "private_key": "bar",
+  "client_email": "foo@bar.iam.gserviceaccount.com",
+  "client_id": "12345",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/foo%40bar.iam.gserviceaccount.com"
+}

--- a/tasks/terraform-cli/src/tests/steps/task-context.steps.ts
+++ b/tasks/terraform-cli/src/tests/steps/task-context.steps.ts
@@ -24,7 +24,13 @@ export class TaskContextSteps {
         this.ctx.secureVarsFileId = id;
         this.ctx.secureVarsFileName = name;
         process.env[`SECUREFILE_NAME_${id}`] = name;
-    }  
+    }
+    
+    @given("gcs backend credential file specified with id {string} and name {string}")
+    public inputGcpCredentialFileFile(id: string, name: string){
+        this.ctx.backendGcsCredentials = id;
+        process.env[`SECUREFILE_NAME_${id}`] = name;
+    }
     
     @given("azurerm backend service connection {string} exists as")
     public inputAzureRmBackendServiceEndpoint(backendServiceName: string, table: DataTable){
@@ -86,6 +92,14 @@ export class TaskContextSteps {
         this.ctx.backendAwsBucket = backend.bucket;
         this.ctx.backendAwsKey = backend.key;
         this.ctx.backendAwsRegion = backend.region;
+    }
+
+    @given("gcs backend type selected with the following bucket")
+    public inputGcsBackend(table: DataTable){
+        var backend = table.rowsHash();
+        this.ctx.backendType = BackendTypes.gcs;
+        this.ctx.backendGcsBucket = backend.bucket;
+        this.ctx.backendGcsPrefix = backend.prefix;
     }
 
     @given("aws backend type selected without bucket configuration")

--- a/tasks/terraform-cli/task.json
+++ b/tasks/terraform-cli/task.json
@@ -23,11 +23,18 @@
             "displayName": "AzureRM Backend Configuration",
             "isExpanded": false,
             "visibleRule": "command = init && backendType = azurerm"
-        },{
+        },
+        {
           "name": "backendAws",
           "displayName": "AWS Backend Configuration",
           "isExpanded": false,
           "visibleRule": "command = init && backendType = aws"
+        },
+        {
+          "name": "backendGcs",
+          "displayName": "GCS Backend Configuration",
+          "isExpanded": false,
+          "visibleRule": "command = init && backendType = gcs"
         },
         {
             "name": "providers",
@@ -155,7 +162,8 @@
                 "local": "local",
                 "azurerm": "azurerm",
                 "selfConfigured": "self-configured",
-                "aws": "aws"
+                "aws": "aws",
+                "gcs": "gcs"
             },
             "properties": {
                 "EditableOptions": "False"
@@ -349,6 +357,30 @@
             "required": false,
             "helpMarkDown": "The default region for the AWS Provider configuration. Sets env ARM_DEFAULT_REGION to the value provided.",
             "groupName": "providers"
+        },
+        {
+            "name": "backendGcsCredentials",
+            "type": "secureFile",
+            "label": "Google Credentials JSON File",
+            "required": false,
+            "helpMarkDown": "Secure file containing GCP account credentials in JSON format.",
+            "groupName": "backendGcs"
+        },
+        {
+            "name": "backendGcsBucket",
+            "type": "string",
+            "label": "Bucket",
+            "required": false,
+            "helpMarkDown": "The bucket's name. If left empty, this is assumed to be self-configured.",
+            "groupName": "backendGcs"
+        },
+        {
+            "name": "backendGcsPrefix",
+            "type": "string",
+            "label": "Prefix",
+            "required": false,
+            "helpMarkDown": "The GCS prefix inside the bucket. If left empty, this is assumed to be self-configured.",
+            "groupName": "backendGcs"
         }
     ],
     "execution": {

--- a/templates/gcp/.terraform/.gitignore
+++ b/templates/gcp/.terraform/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/templates/gcp/main.tf
+++ b/templates/gcp/main.tf
@@ -1,0 +1,12 @@
+terraform {
+  backend "gcs" {
+  }
+}
+
+provider "google" {
+}
+
+resource "google_storage_bucket" "gcsb_test" {
+  name          = "gcs-test-eus-czp"
+  location      = "US"
+}


### PR DESCRIPTION
This adds support for using Google Cloud Storage as the terraform backend.

```yaml
- task: charleszipp.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
  displayName: 'terraform init'
  inputs:
    command: init
    workingDirectory: $(test_templates_dir)
    backendType: gcs
    # Google Credentials (i.e. for service account) in JSON file format in Azure DevOps Secure Files
    backendGcsCredentials: gcs-backend-key.json
    # GCS bucket name
    backendGcsBucket: gcs-trfrm-alpha-eus-czp
    # GCS Bucket path to state file
    backendGcsPrefix: 'azure-pipelines-terraform/infrax'
```

All gcs backend inputs are optional to allow for partial configuration (i.e. some config in task inputs and others from self configured env variables). This is in line with what was added as part of #15 

Authentication is facilitated by a key file in json format being uploaded to Library > Secure Files. The task will download the file to the agent and use it to authenticate against the target GCS bucket.