### PR TITLE
adds support for google provider

### DIFF
--- a/overview.md
+++ b/overview.md
@@ -26,6 +26,7 @@ The Terraform CLI task support the following [Public Cloud](https://registry.ter
 
 - azurerm
 - aws
+- google
 
 > NOTE: It is possible to leverage other providers by providing configuration via environment variables using [secure files](#secure-variable-secrets) or, `-backend-config=key=value` within `commandOptions` input.
 
@@ -93,7 +94,8 @@ When running the other commands, `terraform version` is also run so that the ver
 The TerraformCLI task supports configuring the following public cloud providers. The task supports configuring multiple providers simultaneously to support multi-cloud deployments.
 
 - azurerm - Authenticates via Azure Resource Manager Service Connection included within Azure DevOps.
-- **aws (NEW)** - Authenticates via AWS Service Connection made available via the [AWS Toolkit](https://marketplace.visualstudio.com/items?itemName=AmazonWebServices.aws-vsts-tools) extension.
+- aws - Authenticates via AWS Service Connection made available via the [AWS Toolkit](https://marketplace.visualstudio.com/items?itemName=AmazonWebServices.aws-vsts-tools) extension.
+- google - Authenticates via service account JSON formatted key file uploaded to Azure DevOps secure files.
 
 ### Azure Service Connection / Service Principal Integration
 
@@ -181,9 +183,27 @@ When executing commands that interact with AWS such as `plan`, `apply`, and `des
 
 > NOTE: This depends on the AWS Service Connection included with the [AWS Toolkit]([AWS Toolkit](https://marketplace.visualstudio.com/items?itemName=AmazonWebServices.aws-vsts-tools) extension.
 
+### Google Cloud Platform (GCP) Key File / Service Account Integration
+
+When executing commands that interact with GCP such as `plan`, `apply`, and `destroy`, the task can utilize a JSON formatted key file uploaded to Azure DevOps Secure Files to authorize operations. This is specified via the `providerGoogleCredentials` input. This input should be the name of the secure file containing the JSON formatted key.
+
+```yaml
+- task: charleszipp.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
+  displayName: 'terraform plan'
+  inputs:
+    command: plan
+    workingDirectory: $(test_templates_dir)
+    # Google Credentials (i.e. for service account) in JSON file format in Azure DevOps Secure Files
+    providerGoogleCredentials: gcp-service-account-key.json
+    # The default project name where resources are managed. Defining project on a resource takes precedence over this.
+    providerGoogleProject: gcs-trfrm-${{ parameters.stage }}-eus-czp
+    # The default region where resources are managed. Defining region on a resource takes precedence over this.
+    providerGoogleRegion: 'us-east-1'
+```
+
 ### Configuring Other Cloud Providers
 
-Other cloud providers such as **Google Cloud (GCP)** can be configured using [secure env files](#secure-variable-secrets). See [`aws_self_configured.yml`](https://github.com/charleszipp/azure-pipelines-tasks-terraform/blob/main/pipelines/test/aws_self_configured.yml) for example.
+Other cloud providers can be configured using [secure env files](#secure-variable-secrets). See [`aws_self_configured.yml`](https://github.com/charleszipp/azure-pipelines-tasks-terraform/blob/main/pipelines/test/aws_self_configured.yml) for example.
 
 ## Remote, Local and Self-configured Backend State Support
 
@@ -438,7 +458,7 @@ Skip apply if destroy operations
         commandOptions: '$(System.DefaultWorkingDirectory)/terraform.tfplan'
 ```
 
-## **Workspaces (NEW)**
+## Workspaces
 
 The task supports managing workspaces within pipelines. The following workspace subcommands are supported.
 

--- a/pipelines/test/gcp_credential_file.yml
+++ b/pipelines/test/gcp_credential_file.yml
@@ -21,6 +21,36 @@ jobs:
         command: init
         workingDirectory: $(test_templates_dir)
         backendType: gcs
-        backendGcsCredentials: gcs-backend-key.json
+        backendGcsCredentials: gcp-service-account-key.json
         backendGcsBucket: gcs-trfrm-${{ parameters.stage }}-eus-czp
         backendGcsPrefix: 'azure-pipelines-terraform/gcp_credential_file'
+    - task: charleszipp.azure-pipelines-tasks-terraform-${{ parameters.stage }}.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
+      displayName: 'terraform validate'
+      inputs:
+        workingDirectory: $(test_templates_dir)
+    - task: charleszipp.azure-pipelines-tasks-terraform-${{ parameters.stage }}.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
+      displayName: 'terraform plan'
+      inputs:
+        command: plan
+        workingDirectory: $(test_templates_dir)
+        providerGoogleCredentials: gcp-service-account-key.json
+        providerGoogleProject: gcs-trfrm-${{ parameters.stage }}-eus-czp
+        providerGoogleRegion: 'us-east-1'
+        commandOptions: '-out=$(System.DefaultWorkingDirectory)/terraform.tfplan'
+    - task: charleszipp.azure-pipelines-tasks-terraform-${{ parameters.stage }}.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
+      displayName: 'terraform apply'
+      inputs:
+        command: apply
+        workingDirectory: $(test_templates_dir)
+        providerGoogleCredentials: gcp-service-account-key.json
+        providerGoogleProject: gcs-trfrm-${{ parameters.stage }}-eus-czp        
+        providerGoogleRegion: 'us-east-1'
+        commandOptions: '$(System.DefaultWorkingDirectory)/terraform.tfplan'
+    - task: charleszipp.azure-pipelines-tasks-terraform-${{ parameters.stage }}.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
+      displayName: 'terraform destroy'
+      inputs:
+        command: destroy
+        workingDirectory: $(test_templates_dir)
+        providerGoogleCredentials: gcp-service-account-key.json
+        providerGoogleProject: gcs-trfrm-${{ parameters.stage }}-eus-czp        
+        providerGoogleRegion: 'us-east-1'

--- a/tasks/terraform-cli/src/context/azdo-task-context.ts
+++ b/tasks/terraform-cli/src/context/azdo-task-context.ts
@@ -202,15 +202,27 @@ export default class AzdoTaskContext implements ITaskContext {
     @trackValue("inputs.backends.gcs.credentials", usesBackend(BackendTypes.gcs), true)
     get backendGcsCredentials(){
       return this.getInput("backendGcsCredentials");
-    };
+    }
     @trackValue("inputs.backends.gcs.bucket", usesBackend(BackendTypes.gcs), true)
     get backendGcsBucket(){
       return this.getInput("backendGcsBucket");
-    };
+    }
     @trackValue("inputs.backends.gcs.prefix", usesBackend(BackendTypes.gcs), true)
     get backendGcsPrefix(){
       return this.getInput("backendGcsPrefix");
-    };
+    }
+    @trackValue("inputs.providers.google.creds", usesProvider, true)
+    get providerGoogleCredentials() {
+      return this.getInput("providerGoogleCredentials");
+    }
+    @trackValue("inputs.providers.google.project", usesProvider, true)
+    get providerGoogleProject() {
+      return this.getInput("providerGoogleProject");
+    }
+    @trackValue("inputs.providers.google.region", usesProvider, true)
+    get providerGoogleRegion() {
+      return this.getInput("providerGoogleRegion");
+    }
     finished() {
         this.finishedAt = process.hrtime(this.startedAt);
         this.runTime = this.finishedAt[1] / 1000000;

--- a/tasks/terraform-cli/src/context/index.ts
+++ b/tasks/terraform-cli/src/context/index.ts
@@ -58,6 +58,9 @@ export interface ITaskContext {
     backendGcsCredentials: string;
     backendGcsBucket: string;
     backendGcsPrefix: string;
+    providerGoogleCredentials?: string;
+    providerGoogleProject?: string;
+    providerGoogleRegion?: string;
 }
 
 export const TRACKED_CONTEXT_PROPERTIES_METADATA_KEY = Symbol("propLogMetadata");

--- a/tasks/terraform-cli/src/context/mock-task-context.ts
+++ b/tasks/terraform-cli/src/context/mock-task-context.ts
@@ -58,6 +58,9 @@ export default class MockTaskContext implements ITaskContext {
     backendGcsCredentials: string = "";
     backendGcsBucket: string = "";
     backendGcsPrefix: string = "";
+    providerGoogleCredentials?: string;
+    providerGoogleProject?: string;
+    providerGoogleRegion?: string;
 
     constructor() {
         this.startedAt = process.hrtime();

--- a/tasks/terraform-cli/src/providers/google.ts
+++ b/tasks/terraform-cli/src/providers/google.ts
@@ -1,0 +1,36 @@
+import { ITerraformProvider } from ".";
+
+interface GoogleProviderConfiguration{
+  providerGoogleCredentials?: string,
+  providerGoogleProject?: string,
+  providerGoogleRegion?: string,
+}
+
+export default class GoogleProvider implements ITerraformProvider {
+  constructor(private readonly config: GoogleProviderConfiguration) {
+  }
+
+  isDefined(): boolean{
+    if(this.config.providerGoogleCredentials
+      || this.config.providerGoogleProject
+      || this.config.providerGoogleRegion)
+      {
+        return true;
+      }
+      else{
+        return false;
+      }
+  }
+  
+  async init(): Promise<void> {
+    if(this.config.providerGoogleCredentials){
+      process.env['GOOGLE_CREDENTIALS'] = this.config.providerGoogleCredentials;
+    }
+    if(this.config.providerGoogleProject){
+      process.env['GOOGLE_PROJECT'] = this.config.providerGoogleProject;
+    }
+    if(this.config.providerGoogleRegion){
+      process.env['GOOGLE_REGION'] = this.config.providerGoogleProject;
+    }
+  }
+}

--- a/tasks/terraform-cli/src/providers/google.ts
+++ b/tasks/terraform-cli/src/providers/google.ts
@@ -1,4 +1,5 @@
 import { ITerraformProvider } from ".";
+import { ITaskAgent } from "../task-agent";
 
 interface GoogleProviderConfiguration{
   providerGoogleCredentials?: string,
@@ -7,7 +8,9 @@ interface GoogleProviderConfiguration{
 }
 
 export default class GoogleProvider implements ITerraformProvider {
-  constructor(private readonly config: GoogleProviderConfiguration) {
+  constructor(
+    private readonly agent: ITaskAgent,
+    private readonly config: GoogleProviderConfiguration) {
   }
 
   isDefined(): boolean{
@@ -23,8 +26,9 @@ export default class GoogleProvider implements ITerraformProvider {
   }
   
   async init(): Promise<void> {
-    if(this.config.providerGoogleCredentials){
-      process.env['GOOGLE_CREDENTIALS'] = this.config.providerGoogleCredentials;
+    if(this.config.providerGoogleCredentials){      
+      const credentials = await this.agent.downloadSecureFile(this.config.providerGoogleCredentials);
+      process.env['GOOGLE_CREDENTIALS'] = credentials;
     }
     if(this.config.providerGoogleProject){
       process.env['GOOGLE_PROJECT'] = this.config.providerGoogleProject;

--- a/tasks/terraform-cli/src/task.ts
+++ b/tasks/terraform-cli/src/task.ts
@@ -2,6 +2,7 @@ import * as commands from "./commands";
 import { ITaskContext } from "./context";
 import { ILogger } from "./logger";
 import { AwsProvider, AzureRmProvider, TerraformProviderContext } from "./providers";
+import GoogleProvider from "./providers/google";
 import { IRunner } from "./runners";
 import { ITaskAgent } from "./task-agent";
 
@@ -16,7 +17,8 @@ export class Task {
         const providers = new TerraformProviderContext(
           logger,
           new AzureRmProvider(runner, ctx),
-          new AwsProvider(ctx)
+          new AwsProvider(ctx),
+          new GoogleProvider(ctx)
         )
         this.commands = {    
           "version": new commands.VersionCommandHandler(runner, logger),

--- a/tasks/terraform-cli/src/task.ts
+++ b/tasks/terraform-cli/src/task.ts
@@ -18,7 +18,7 @@ export class Task {
           logger,
           new AzureRmProvider(runner, ctx),
           new AwsProvider(ctx),
-          new GoogleProvider(ctx)
+          new GoogleProvider(taskAgent, ctx)
         )
         this.commands = {    
           "version": new commands.VersionCommandHandler(runner, logger),

--- a/tasks/terraform-cli/task.json
+++ b/tasks/terraform-cli/task.json
@@ -381,6 +381,30 @@
             "required": false,
             "helpMarkDown": "The GCS prefix inside the bucket. If left empty, this is assumed to be self-configured.",
             "groupName": "backendGcs"
+        },
+        {
+            "name": "providerGoogleCredentials",
+            "type": "secureFile",
+            "label": "Google Credentials JSON File",
+            "required": false,
+            "helpMarkDown": "Secure file containing GCP account credentials in JSON format.",
+            "groupName": "providers"
+        },
+        {
+            "name": "providerGoogleProject",
+            "type": "string",
+            "label": "Project",
+            "required": false,
+            "helpMarkDown": "The default project name where resources are managed. Defining project on a resource takes precedence over this.",
+            "groupName": "providers"
+        },
+        {
+            "name": "providerGoogleRegion",
+            "type": "string",
+            "label": "Region",
+            "required": false,
+            "helpMarkDown": "The default region where resources are managed. Defining region on a resource takes precedence over this.",
+            "groupName": "providers"
         }
     ],
     "execution": {


### PR DESCRIPTION
These changes add more direct integration for using the [Google Cloud Platform provider](https://registry.terraform.io/providers/hashicorp/google/latest) to deploy resources into a GCP project.

```yaml
- task: charleszipp.azure-pipelines-tasks-terraform.azure-pipelines-tasks-terraform-cli.TerraformCLI@0
  displayName: 'terraform plan'
  inputs:
    command: plan
    workingDirectory: $(test_templates_dir)
    # Google Credentials (i.e. for service account) in JSON file format in Azure DevOps Secure Files
    providerGoogleCredentials: gcp-service-account-key.json
    # The default project name where resources are managed. Defining project on a resource takes precedence over this.
    providerGoogleProject: gcs-trfrm-${{ parameters.stage }}-eus-czp
    # The default region where resources are managed. Defining region on a resource takes precedence over this.
    providerGoogleRegion: 'us-east-1'
```

Authentication is facilitated by a key file in json format being uploaded to Library > Secure Files. The task will download the file to the agent and use it to authenticate against the target GCS bucket.