### PR TITLE
make subscription id input optional when using management group service connections

### DIFF
--- a/overview.md
+++ b/overview.md
@@ -225,8 +225,6 @@ The task currently supports the following backend configurations
 
 If azurerm selected, the task will prompt for a service connection and storage account details to use for the backend. *The task supports both Subscription and Management Group scoped service connections*
 
-> Note: If using a management group scoped service connection, ensure the subscription id of the target backend is defined via the `backendAzureRmSubscriptionId` input.
-
 ```yaml
 - task: TerraformCLI
   displayName: 'terraform init'

--- a/tasks/terraform-cli/src/backends/azurerm.ts
+++ b/tasks/terraform-cli/src/backends/azurerm.ts
@@ -12,9 +12,8 @@ export default class AzureRMBackend implements ITerraformBackend {
         if (ctx.backendServiceArmAuthorizationScheme != "ServicePrincipal") {
             throw "Terraform backend initialization for AzureRM only support service principal authorization";
         }
-        if(!ctx.backendServiceArmSubscriptionId && !ctx.backendAzureRmSubscriptionId){
-          throw "Unable to resolve subscription id. Subscription Id must be defined either on Backend Service Connection with Subscription Id scope or, explicitly set in the `backendAzureRmSubscriptionId` input when using other scopes such as Management Group."
-        }
+        
+        const subscriptionId = ctx.backendAzureRmSubscriptionId || ctx.backendServiceArmSubscriptionId;
 
         let backendConfig: any = {
             storage_account_name: ctx.backendAzureRmStorageAccountName,
@@ -25,13 +24,17 @@ export default class AzureRMBackend implements ITerraformBackend {
 
         //use the arm_* prefix config only for versions before 0.12.0
         if(ctx.terraformVersionMajor === 0 && typeof(ctx.terraformVersionMinor) == 'number' && ctx.terraformVersionMinor < 12){
-            backendConfig.arm_subscription_id = ctx.backendAzureRmSubscriptionId || ctx.backendServiceArmSubscriptionId;
+            if(subscriptionId){
+              backendConfig.arm_subscription_id = subscriptionId
+            }
             backendConfig.arm_tenant_id = ctx.backendServiceArmTenantId;
             backendConfig.arm_client_id = ctx.backendServiceArmClientId;
             backendConfig.arm_client_secret = ctx.backendServiceArmClientSecret;
         }
         else{
-            backendConfig.subscription_id = ctx.backendAzureRmSubscriptionId || ctx.backendServiceArmSubscriptionId;
+            if(subscriptionId){
+              backendConfig.subscription_id = subscriptionId
+            }
             backendConfig.tenant_id = ctx.backendServiceArmTenantId;
             backendConfig.client_id = ctx.backendServiceArmClientId;
             backendConfig.client_secret = ctx.backendServiceArmClientSecret;

--- a/tasks/terraform-cli/src/providers/azurerm.ts
+++ b/tasks/terraform-cli/src/providers/azurerm.ts
@@ -24,11 +24,10 @@ export default class AzureRMProvider implements ITerraformProvider {
       }
       const subscriptionId = this.ctx.providerAzureRmSubscriptionId || this.ctx.environmentServiceArmSubscriptionId;
 
-      if(!subscriptionId){
-        throw "Unable to resolve subscription id. Subscription Id must be defined either on AzureRM Provider Service Connection with Subscription Id scope or, explicitly set in the `providerAzureRmSubscriptionId` input when using other scopes such as Management Group."
+      if(subscriptionId){
+        process.env['ARM_SUBSCRIPTION_ID']  = subscriptionId;
       }      
 
-      process.env['ARM_SUBSCRIPTION_ID']  = subscriptionId;
       process.env['ARM_TENANT_ID']        = this.ctx.environmentServiceArmTenantId;
       process.env['ARM_CLIENT_ID']        = this.ctx.environmentServiceArmClientId;
       process.env['ARM_CLIENT_SECRET']    = this.ctx.environmentServiceArmClientSecret;

--- a/tasks/terraform-cli/src/tests/features/terraform-apply-sub-override.feature
+++ b/tasks/terraform-cli/src/tests/features/terraform-apply-sub-override.feature
@@ -85,6 +85,18 @@ Feature: terraform apply azurerm with subscription override
             | -u servicePrincipal1      |
             | -p servicePrincipalKey123 |
         And task configured to run az login
-        And running command "terraform apply" returns successful result
+        And running command "terraform apply -auto-approve" returns successful result
         When the terraform cli task is run
-        Then the terraform cli task fails with message "Unable to resolve subscription id. Subscription Id must be defined either on AzureRM Provider Service Connection with Subscription Id scope or, explicitly set in the `providerAzureRmSubscriptionId` input when using other scopes such as Management Group."
+        Then the terraform cli task executed command "terraform apply -auto-approve" with the following environment variables
+            | ARM_TENANT_ID       | ten1                   |
+            | ARM_CLIENT_ID       | servicePrincipal1      |
+            | ARM_CLIENT_SECRET   | servicePrincipalKey123 |
+        And azure login is executed with the following options
+            | option                |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
+        And the terraform cli task is successful
+        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
+        

--- a/tasks/terraform-cli/src/tests/features/terraform-destroy-sub-override.feature
+++ b/tasks/terraform-cli/src/tests/features/terraform-destroy-sub-override.feature
@@ -74,9 +74,29 @@ Feature: terraform destroy azurerm with subscription override
         And terraform command is "destroy"
         And azurerm service connection "dev" exists as
             | scheme         | ServicePrincipal       |
+            | subscriptionId | sub2                   |
             | tenantId       | ten1                   |
             | clientId       | servicePrincipal1      |
             | clientSecret   | servicePrincipalKey123 |
-        And running command "terraform destroy" returns successful result
+        And running command "terraform destroy -auto-approve" returns successful result
+        And azure cli exists
+        And running command "az login" with the following options returns successful result
+            | option                    |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
+        And task configured to run az login
         When the terraform cli task is run
-        Then the terraform cli task fails with message "Unable to resolve subscription id. Subscription Id must be defined either on AzureRM Provider Service Connection with Subscription Id scope or, explicitly set in the `providerAzureRmSubscriptionId` input when using other scopes such as Management Group."
+        Then the terraform cli task executed command "terraform destroy -auto-approve" with the following environment variables
+            | ARM_TENANT_ID       | ten1                   |
+            | ARM_CLIENT_ID       | servicePrincipal1      |
+            | ARM_CLIENT_SECRET   | servicePrincipalKey123 |
+        And azure login is executed with the following options
+            | option                |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
+        And the terraform cli task is successful
+        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"

--- a/tasks/terraform-cli/src/tests/features/terraform-plan-with-sub-override.feature
+++ b/tasks/terraform-cli/src/tests/features/terraform-plan-with-sub-override.feature
@@ -74,9 +74,29 @@ Feature: terraform plan azurerm with subscription override
         And terraform command is "plan"
         And azurerm service connection "dev" exists as
             | scheme         | ServicePrincipal       |
+            | subscriptionId | sub2                   |
             | tenantId       | ten1                   |
             | clientId       | servicePrincipal1      |
             | clientSecret   | servicePrincipalKey123 |
+        And azure cli exists
+        And running command "az login" with the following options returns successful result
+            | option                    |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
+        And task configured to run az login
         And running command "terraform plan" returns successful result
         When the terraform cli task is run
-        Then the terraform cli task fails with message "Unable to resolve subscription id. Subscription Id must be defined either on AzureRM Provider Service Connection with Subscription Id scope or, explicitly set in the `providerAzureRmSubscriptionId` input when using other scopes such as Management Group."
+        Then the terraform cli task executed command "terraform plan" with the following environment variables
+            | ARM_TENANT_ID       | ten1                   |
+            | ARM_CLIENT_ID       | servicePrincipal1      |
+            | ARM_CLIENT_SECRET   | servicePrincipalKey123 |
+        And azure login is executed with the following options
+            | option                |
+            | --service-principal       |
+            | -t ten1                   |
+            | -u servicePrincipal1      |
+            | -p servicePrincipalKey123 |
+        And the terraform cli task is successful
+        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"

--- a/tasks/terraform-cli/task.json
+++ b/tasks/terraform-cli/task.json
@@ -108,7 +108,7 @@
             "label": "AzureRM Provider Service Connection",
             "required": false,
             "visibleRule": "command = plan || command = apply || command = destroy || command = refresh || command = import",
-            "helpMarkDown": "Select an Azure service connection for azurerm provider authorization. Both Subscription & Management Group Scopes are supported. *If using Management Group Scoped service connection, ensure the Subscription Id is provided in the `providerAzureRmSubscriptionId` input.* **This field is optional.** Leave empty should you choose to self-configure the provider(s) used or the provider is not used. Provider environment variables can be configured securely by selecting an env file from the `Secured Variables File` pick list.",
+            "helpMarkDown": "Select an Azure service connection for azurerm provider authorization. Both Subscription & Management Group Scopes are supported. If using Management Group Scoped service connection, the subscription id can be self configured within the template provider configuration, with environment variable, or provided in the `providerAzureRmSubscriptionId` input.* **This field is optional.** Leave empty should you choose to self-configure the provider(s) used or the provider is not used. Provider environment variables can be configured securely by selecting an env file from the `Secured Variables File` pick list.",
             "groupName": "providers"
         },
         {
@@ -201,7 +201,7 @@
             "type": "connectedService:AzureRM",
             "label": "Backend Azure Service Connection",
             "required": false,
-            "helpMarkDown": "Select an Azure Resource Manager service connection for backend authorization. Both Subscription & Management Group Scopes are supported. *If using Management Group Scoped service connection, ensure the Subscription Id is provided in the `backendAzureRmSubscriptionId` input.*",
+            "helpMarkDown": "Select an Azure Resource Manager service connection for backend authorization. Both Subscription & Management Group Scopes are supported. If using Management Group Scoped service connection, the subscription id can be self configured within the template backend configuration, with environment variable, or provided in the `backendAzureRmSubscriptionId` input.",
             "groupName": "backendAzureRm"
         },
         {
@@ -209,7 +209,7 @@
             "type": "string",
             "label": "Azure Subscription Id",
             "required": false,
-            "helpMarkDown": "The subscription id where the backend should be located. If provided, this will override the subscription id defined within the service connection. This should be provided when using Management Group scoped service connection.",
+            "helpMarkDown": "The subscription id where the backend should be located. If provided, this will override the subscription id defined within the service connection.",
             "groupName": "backendAzureRm"
         },
         {


### PR DESCRIPTION
Resolves #250 

This change will make the `backendAzureRmSubscriptionId` and `providerAzureRmSubscriptionId` inputs optional when using management group service connections.