### PR TITLE
Fix issue with unexpected token in json

### DIFF
--- a/tasks/terraform-cli/src/commands/tf-show.ts
+++ b/tasks/terraform-cli/src/commands/tf-show.ts
@@ -8,15 +8,15 @@ import { ITaskAgent } from "../task-agent";
 export class TerraformShow implements ICommand {
     constructor(
         private readonly taskAgent: ITaskAgent,
-        private readonly runner: IRunner, 
+        private readonly runner: IRunner,
         private readonly logger: ILogger
         ) {
     }
 
-    async exec(ctx: ITaskContext): Promise<CommandResponse> {        
+    async exec(ctx: ITaskContext): Promise<CommandResponse> {
         const options = await new RunWithTerraform(ctx, true)
-            .withSecureVarFile(this.taskAgent, ctx.secureVarsFileId, ctx.secureVarsFileName)    
-            .withJsonOutput(ctx.commandOptions)            
+            .withSecureVarFile(this.taskAgent, ctx.secureVarsFileId, ctx.secureVarsFileName)
+            .withJsonOutput(ctx.commandOptions)
             .withCommandOptions(ctx.commandOptions)
             .withPlanOrStateFile(ctx.planOrStateFilePath)
             .build();
@@ -40,7 +40,8 @@ export class TerraformShow implements ICommand {
 
     private detectDestroyChanges(ctx: ITaskContext, result: string): void
     {
-        const resultNoEol = result.replace(/(\r\n|\r|\n|\\n|\t|\\")/gm, "");
+        // Remove unexpected characters at the end of the result string
+        const resultNoEol = result.replace(/(\r\n|\r|\n|\\n|\t|\\")$/gm, "");
         let jsonResult = JSON.parse(resultNoEol);
         const deleteValue = "delete";
 
@@ -54,7 +55,7 @@ export class TerraformShow implements ICommand {
                 }
             }
         }
-        
+
         this.logger.debug("No destroy detected")
         this.setDestroyDetectedFlag(ctx, false);
     }

--- a/tasks/terraform-cli/src/tests/features/terraform-show.feature
+++ b/tasks/terraform-cli/src/tests/features/terraform-show.feature
@@ -33,7 +33,7 @@ Feature: terraform show
         And the terraform cli task is successful
         And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
         And pipeline variable "TERRAFORM_PLAN_HAS_DESTROY_CHANGES" is set to "true"
-        
+
         Scenario: show tf plan file with destroy operations - apiManagement
         Given terraform exists
         And terraform command is "show"
@@ -97,6 +97,17 @@ Feature: terraform show
         Given terraform exists
         And terraform command is "show"
         And running command "terraform show -json show.plan" returns successful result with stdout from file "./src/tests/stdout_tf_show_tfplan_output_only.json"
+        And the target plan or state file is "show.plan"
+        When the terraform cli task is run
+        Then the terraform cli task executed command "terraform show -json show.plan"
+        And the terraform cli task is successful
+        And pipeline variable "TERRAFORM_LAST_EXITCODE" is set to "0"
+        And pipeline variable "TERRAFORM_PLAN_HAS_DESTROY_CHANGES" is set to "false"
+
+        Scenario: show tf plan that contains newlines
+        Given terraform exists
+        And terraform command is "show"
+        And running command "terraform show -json show.plan" returns successful result with stdout from file "./src/tests/stdout_tf_show_tfplan_with_newline.json"
         And the target plan or state file is "show.plan"
         When the terraform cli task is run
         Then the terraform cli task executed command "terraform show -json show.plan"

--- a/tasks/terraform-cli/src/tests/stdout_tf_show_tfplan_with_newline.json
+++ b/tasks/terraform-cli/src/tests/stdout_tf_show_tfplan_with_newline.json
@@ -1,0 +1,23 @@
+{
+    "format_version": "0.1",
+    "terraform_version": "0.13.4",
+    "planned_values": {
+        "outputs": {
+            "some_string": {
+                "sensitive": false,
+                "value": "value\\nwith\\nnewline\\n"
+            }
+        },
+        "root_module": {}
+    },
+    "output_changes": {
+        "some_string": {
+            "actions": [
+                "create"
+            ],
+            "before": null,
+            "after": "value\\nwith\\nnewline\\n",
+            "after_unknown": false
+        }
+    }
+}


### PR DESCRIPTION
Issue was caused by newlines in the json values `\\n` being replaced to
`\`. If the following character was not a known escape character then
the exception would be thrown.

Fixed by changing the regex to match only on a line ending.
Added unit test.

fixes #61