### PR TITLE
fix: set correct input value for resource addesses in state

### DIFF
--- a/tasks/terraform-cli/task.json
+++ b/tasks/terraform-cli/task.json
@@ -361,7 +361,7 @@
             "helpMarkDown": "The name of the destination resource"
         },
         {
-            "name": "stateAddresses",
+            "name": "stateSubCommandAddresses",
             "type": "string",
             "label": "State list and rm addresses",
             "required": false,


### PR DESCRIPTION
When running a Classic task for terraform state remove the input for "state list and rm addresses" was being passed to the variable `stateAddresses` instead of `stateSubCommandAddresses`  keeping the required field `stateSubCommandAddresses` empty. 

This issue made the `terraform state rm` command unusable with classic pipelines where as YAML pipelines work due to the values being explicitly assigned in definition.

Fixes #259 | Azure DevOps Release Pipeline task terraform state remove : Error: Input required: stateSubCommandAddresses
