### PR TITLE
Bug: Enable case insensitive auth scheme

### DIFF
--- a/tasks/terraform-cli/src/authentication/azurerm.ts
+++ b/tasks/terraform-cli/src/authentication/azurerm.ts
@@ -32,15 +32,24 @@ export class AzureRMAuthentication {
     return workloadIdentityFederationCredentials;
   }
 
-  static getAuthorizationScheme(sourceAuthorizationScheme: string) : AuthorizationScheme {
-    let authorizationScheme : AuthorizationScheme = AuthorizationScheme.ServicePrincipal;
-
-    authorizationScheme = AuthorizationScheme[sourceAuthorizationScheme as keyof typeof AuthorizationScheme];
-    if(!authorizationScheme){
-      throw "Terraform only supports service principal, managed service identity or workload identity federation authorization";
+  static getAuthorizationScheme(authorizationScheme: string) : AuthorizationScheme {
+    if(authorizationScheme == undefined) {
+      throw('The authorization scheme is missing. Terraform only supports service principal, managed service identity or workload identity federation authorization');
     }
 
-    return authorizationScheme;
+    if(authorizationScheme.toLowerCase() == AuthorizationScheme.ServicePrincipal){
+        return AuthorizationScheme.ServicePrincipal;
+    }
+
+    if(authorizationScheme.toLowerCase() == AuthorizationScheme.ManagedServiceIdentity){
+        return AuthorizationScheme.ManagedServiceIdentity;
+    }
+
+    if(authorizationScheme.toLowerCase() == AuthorizationScheme.WorkloadIdentityFederation){
+        return AuthorizationScheme.WorkloadIdentityFederation;
+    }
+
+    throw('No matching authorization scheme was found. Terraform only supports service principal, managed service identity or workload identity federation authorization');
   }
 }
 

--- a/tasks/terraform-cli/src/tests/features/terraform-apply.feature
+++ b/tasks/terraform-cli/src/tests/features/terraform-apply.feature
@@ -154,7 +154,7 @@ Feature: terraform apply
         And task configured to run az login
         And running command "terraform apply" returns successful result
         When the terraform cli task is run
-        Then the terraform cli task fails with message "Terraform only supports service principal, managed service identity or workload identity federation authorization"
+        Then the terraform cli task fails with message "No matching authorization scheme was found. Terraform only supports service principal, managed service identity or workload identity federation authorization"
     
     Scenario: apply with azurerm and ManagedServiceIdentity auth scheme
         Given terraform exists

--- a/tasks/terraform-cli/src/tests/features/terraform-destroy.feature
+++ b/tasks/terraform-cli/src/tests/features/terraform-destroy.feature
@@ -146,7 +146,7 @@ Feature: terraform destroy
             | clientSecret   | servicePrincipalKey123 |
         And running command "terraform destroy" returns successful result
         When the terraform cli task is run
-        Then the terraform cli task fails with message "Terraform only supports service principal, managed service identity or workload identity federation authorization"
+        Then the terraform cli task fails with message "No matching authorization scheme was found. Terraform only supports service principal, managed service identity or workload identity federation authorization"
 
     Scenario: destroy with azurerm and ManagedServiceIdentity auth scheme
         Given terraform exists

--- a/tasks/terraform-cli/src/tests/features/terraform-plan.feature
+++ b/tasks/terraform-cli/src/tests/features/terraform-plan.feature
@@ -15,7 +15,7 @@ Feature: terraform plan
         Given terraform exists
         And terraform command is "plan"
         And azurerm service connection "dev" exists as
-            | scheme         | ServicePrincipal       |
+            | scheme         | serviceprincipal       |
             | subscriptionId | sub1                   |
             | tenantId       | ten1                   |
             | clientId       | servicePrincipal1      |
@@ -247,7 +247,20 @@ Feature: terraform plan
             | clientSecret   | servicePrincipalKey123 |
         And running command "terraform plan" returns successful result
         When the terraform cli task is run
-        Then the terraform cli task fails with message "Terraform only supports service principal, managed service identity or workload identity federation authorization"
+        Then the terraform cli task fails with message "No matching authorization scheme was found. Terraform only supports service principal, managed service identity or workload identity federation authorization"
+
+    Scenario: plan with empty auth scheme
+        Given terraform exists
+        And terraform command is "plan"
+        And azurerm service connection "dev" exists as
+            | scheme         |  |
+            | subscriptionId | sub1                   |
+            | tenantId       | ten1                   |
+            | clientId       | servicePrincipal1      |
+            | clientSecret   | servicePrincipalKey123 |
+        And running command "terraform plan" returns successful result
+        When the terraform cli task is run
+        Then the terraform cli task fails with message "No matching authorization scheme was found. Terraform only supports service principal, managed service identity or workload identity federation authorization"
 
     Scenario: plan with azurerm and ManagedServiceIdentity auth scheme
         Given terraform exists

--- a/views/terraform-plan/package-lock.json
+++ b/views/terraform-plan/package-lock.json
@@ -40,7 +40,7 @@
         "node-sass": "^9.0.0",
         "prettier": "^2.4.1",
         "rimraf": "^2.6.3",
-        "sass-loader": "^12.3.0",
+        "sass-loader": "^13.3.2",
         "style-loader": "^3.3.1",
         "ts-jest": "^29.0.4",
         "ts-loader": "^9.2.6",
@@ -6548,15 +6548,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/klona": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.5.tgz",
-      "integrity": "sha512-pJiBpiXMbt7dkzXe8Ghj/u4FfXOOa98fPW+bihOJ4SjnoijweJrNThJfd3ifXpXhREjpoF2mZVH1GfS9LV3kHQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -8788,16 +8779,15 @@
       }
     },
     "node_modules/sass-loader": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-12.6.0.tgz",
-      "integrity": "sha512-oLTaH0YCtX4cfnJZxKSLAyglED0naiYfNG1iXfU5w1LNZ+ukoA5DtyDIN5zmKVZwYNJP4KRc5Y3hkWga+7tYfA==",
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-13.3.2.tgz",
+      "integrity": "sha512-CQbKl57kdEv+KDLquhC+gE3pXt74LEAzm+tzywcA0/aHZuub8wTErbjAoNI57rPUWRYRNC5WUnNl8eGJNbDdwg==",
       "dev": true,
       "dependencies": {
-        "klona": "^2.0.4",
         "neo-async": "^2.6.2"
       },
       "engines": {
-        "node": ">= 12.13.0"
+        "node": ">= 14.15.0"
       },
       "funding": {
         "type": "opencollective",
@@ -8805,7 +8795,7 @@
       },
       "peerDependencies": {
         "fibers": ">= 3.1.0",
-        "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0",
+        "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
         "sass": "^1.3.0",
         "sass-embedded": "*",
         "webpack": "^5.0.0"
@@ -15877,12 +15867,6 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
     },
-    "klona": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.5.tgz",
-      "integrity": "sha512-pJiBpiXMbt7dkzXe8Ghj/u4FfXOOa98fPW+bihOJ4SjnoijweJrNThJfd3ifXpXhREjpoF2mZVH1GfS9LV3kHQ==",
-      "dev": true
-    },
     "leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -17549,12 +17533,11 @@
       }
     },
     "sass-loader": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-12.6.0.tgz",
-      "integrity": "sha512-oLTaH0YCtX4cfnJZxKSLAyglED0naiYfNG1iXfU5w1LNZ+ukoA5DtyDIN5zmKVZwYNJP4KRc5Y3hkWga+7tYfA==",
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-13.3.2.tgz",
+      "integrity": "sha512-CQbKl57kdEv+KDLquhC+gE3pXt74LEAzm+tzywcA0/aHZuub8wTErbjAoNI57rPUWRYRNC5WUnNl8eGJNbDdwg==",
       "dev": true,
       "requires": {
-        "klona": "^2.0.4",
         "neo-async": "^2.6.2"
       }
     },

--- a/views/terraform-plan/package.json
+++ b/views/terraform-plan/package.json
@@ -58,7 +58,7 @@
     "node-sass": "^9.0.0",
     "prettier": "^2.4.1",
     "rimraf": "^2.6.3",
-    "sass-loader": "^12.3.0",
+    "sass-loader": "^13.3.2",
     "style-loader": "^3.3.1",
     "ts-jest": "^29.0.4",
     "ts-loader": "^9.2.6",


### PR DESCRIPTION
This PR fixes an issue with handling legacy authorization schemes. It seems the casing changed at some point, so older service connections could be lower case, but new ones are pascal case.