### PR TITLE
Fix last pr

### DIFF
--- a/tasks/terraform-cli/task.json
+++ b/tasks/terraform-cli/task.json
@@ -12,7 +12,7 @@
     ],
     "demands": [],
     "version": {
-        "Major": "#{GitVersion.Major}#",
+        "Major": "#{majorNumber}#",
         "Minor": "#{GitVersion.Minor}#",
         "Patch": "#{GitVersion.Patch}#"
     },

--- a/tasks/terraform-installer/task.json
+++ b/tasks/terraform-installer/task.json
@@ -12,7 +12,7 @@
   ],
   "demands": [],
   "version": {
-    "Major": "#{GitVersion.Major}#",
+    "Major": "#{majorNumber}#",
     "Minor": "#{GitVersion.Minor}#",
     "Patch": "#{GitVersion.Patch}#"
   },


### PR DESCRIPTION
The last PR changed Major to come from GitVersion.Major but that is wrong since we have multiple versions in the same file and only one of them will match the tag (possibly 2, but certainly not the unstable)