### PR TITLE
Add github actions to run tests

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,8 @@
 		"alexkrechik.cucumberautocomplete",
 		"ms-azure-devops.azure-pipelines",
 		"github.copilot",
-		"4ops.terraform"
+		"4ops.terraform",
+		"github.vscode-github-actions"
 	],
 	"postCreateCommand": "npm install -g typescript && npm install",
 }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: Node.js CI
 
 on:
+    push:
+        branches-ignore:
+            - main
     pull_request:
         branches: [ main ]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,11 +10,13 @@ on:
 jobs:
     test-cli:
         runs-on: ubuntu-latest
+        defaults:
+            run:
+                working-directory: tasks/terraform-cli
 
         strategy:
             matrix:
                 node-version: ['18.x', '20.x']
-                working-dir: ['./tasks/terraform-cli', './tasks/terraform-installer']
 
         steps:
         - uses: actions/checkout@v4
@@ -23,6 +25,4 @@ jobs:
           with:
             node-version: ${{ matrix.node-version }}
         - run: npm ci
-          working-directory: ${{ matrix.working-dir }}
         - run: npm test
-          working-directory: ${{ matrix.working-dir }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Node.js CI
+
+on:
+    pull_request:
+        branches: [ main ]
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+
+        strategy:
+            matrix:
+                node-version: [14.x, 16.x, 20.x]
+
+        steps:
+        - name: Checkout repository
+            uses: actions/checkout@v2
+
+        - name: Set up Node.js ${{ matrix.node-version }}
+            uses: actions/setup-node@v2
+            with:
+                node-version: ${{ matrix.node-version }}
+
+        - name: Install dependencies
+            run: npm install
+
+        - name: Run tests
+            run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,17 +13,15 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [14.x, 16.x, 20.x]
+                node-version: ['18.x', '20.x']
 
         steps:
-        - name: Checkout repository
-          uses: actions/checkout@v2
-
-        - name: Set up Node.js ${{ matrix.node-version }}
-          uses: actions/setup-node@v2
+        - uses: actions/checkout@v4
+        - name: Use Node.js ${{ matrix.node-version }}
+          uses: actions/setup-node@v4
           with:
-                node-version: ${{ matrix.node-version }}
-
+            node-version: ${{ matrix.node-version }}
+            
         - name: Install dependencies
           run: npm install
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,13 @@ on:
         branches: [ main ]
 
 jobs:
-    build:
+    test-cli:
         runs-on: ubuntu-latest
 
         strategy:
             matrix:
                 node-version: ['18.x', '20.x']
+                working-dir: ['./tasks/terraform-cli', './tasks/terraform-installer']
 
         steps:
         - uses: actions/checkout@v4
@@ -21,9 +22,6 @@ jobs:
           uses: actions/setup-node@v4
           with:
             node-version: ${{ matrix.node-version }}
-            
-        - name: Install dependencies
-          run: npm install
-
-        - name: Run tests
-          run: npm test
+            working-directory: ${{ matrix.working-dir }}
+        - run: npm ci
+        - run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,15 +14,15 @@ jobs:
 
         steps:
         - name: Checkout repository
-            uses: actions/checkout@v2
+          uses: actions/checkout@v2
 
         - name: Set up Node.js ${{ matrix.node-version }}
-            uses: actions/setup-node@v2
-            with:
+          uses: actions/setup-node@v2
+          with:
                 node-version: ${{ matrix.node-version }}
 
         - name: Install dependencies
-            run: npm install
+          run: npm install
 
         - name: Run tests
-            run: npm test
+          run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,8 @@ jobs:
         - uses: actions/checkout@v4
         - name: Use Node.js ${{ matrix.node-version }}
           uses: actions/setup-node@v4
+          working-directory: ${{ matrix.working-dir }}
           with:
             node-version: ${{ matrix.node-version }}
-            working-directory: ${{ matrix.working-dir }}
         - run: npm ci
         - run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,9 @@ jobs:
         - uses: actions/checkout@v4
         - name: Use Node.js ${{ matrix.node-version }}
           uses: actions/setup-node@v4
-          working-directory: ${{ matrix.working-dir }}
           with:
             node-version: ${{ matrix.node-version }}
         - run: npm ci
+          working-directory: ${{ matrix.working-dir }}
         - run: npm test
+          working-directory: ${{ matrix.working-dir }}

--- a/pipelines/test.yml
+++ b/pipelines/test.yml
@@ -18,7 +18,7 @@ variables:
   Agent.Source.Git.ShallowFetchDepth: 0
   tf_variables_secure_file: 4a0c36e2-bb51-41ed-87b1-2e668c64bb69
   terraform_templates_dir: $(System.DefaultWorkingDirectory)/templates
-  terraformVersion: 1.0.10
+  terraformVersion: 1.9.8
 
 stages:
 - template: templates/integration_tests.yml


### PR DESCRIPTION
The point of this is to allow contributions to know when they've broken the tests.  The tests do no run on ADO without being merged so there was no easy way to know if a PR would actually break something.