### PR TITLE
Fix: Import azure-pipelines-tasks-azure-arm-rest for getFederatedToken

### DIFF
--- a/tasks/terraform-cli/package.json
+++ b/tasks/terraform-cli/package.json
@@ -30,7 +30,7 @@
     "applicationinsights": "^1.8.8",
     "azure-devops-node-api": "^12.0.0",
     "azure-pipelines-task-lib": "^4.6.1",
-    "azure-pipelines-tasks-artifacts-common": "2.241.1",
+    "azure-pipelines-tasks-azure-arm-rest": "3.249.0",
     "dotenv": "^8.2.0",
     "intercept-stdout": "^0.1.2",
     "mock-require": "^3.0.3",

--- a/tasks/terraform-cli/src/context/azdo-task-context.ts
+++ b/tasks/terraform-cli/src/context/azdo-task-context.ts
@@ -1,7 +1,7 @@
 import { ITaskContext, trackValue } from ".";
 import * as tasks from 'azure-pipelines-task-lib/task';
 import { BackendTypes } from "../backends";
-import { getFederatedToken } from "azure-pipelines-tasks-artifacts-common/webapi";
+import { getFederatedToken } from "azure-pipelines-tasks-azure-arm-rest/azCliUtility";
 
 const isCommand = (...commands: string[]) => (ctx: ITaskContext) => commands.includes(ctx.name);
 const isCommandWithSubCommand = (commands: string[], subCommands: string[], subCommand: (ctx: ITaskContext) => string) => (ctx: ITaskContext) => commands.includes(ctx.name) && subCommands.includes(subCommand(ctx));


### PR DESCRIPTION
Old code is using `azure-pipelines-tasks-artifacts-common`
But `getFederatedToken` moved to `azure-pipelines-tasks-azure-arm-rest`

So this PR is to address the issue via fixing imports.

fixes: https://github.com/jason-johnson/azure-pipelines-tasks-terraform/issues/455

Currently after last update of this extension, there are errors globally.
Please review asap.

thx.