### PR TITLE
Move plan output

### DIFF
--- a/tasks/terraform-cli/src/commands/tf-plan.ts
+++ b/tasks/terraform-cli/src/commands/tf-plan.ts
@@ -64,7 +64,7 @@ export class TerraformPlan implements ICommand {
                 default:
                     content = result.stdout
             }
-            this.taskAgent.attachNewFile(ctx.cwd, publishedPlanAttachmentType, ctx.publishPlanResults, content);
+            this.taskAgent.attachNewPlanFile(ctx.cwd, publishedPlanAttachmentType, ctx.publishPlanResults, content);
         }
 
         return result.toCommandResponse();

--- a/tasks/terraform-cli/src/task-agent/azdo-task-agent.ts
+++ b/tasks/terraform-cli/src/task-agent/azdo-task-agent.ts
@@ -60,7 +60,8 @@ export default class TaskAgent implements ITaskAgent {
 
     writeFile(workingDirectory: string, fileName: string, content: string): string {
         const filePath = tasks.resolve(workingDirectory, fileName);
-        fs.mkdirSync(path.dirname(filePath), { recursive: true });
+        const dirname = path.dirname(filePath);
+        fs.existsSync(dirname) || fs.mkdirSync(dirname, { recursive: true });
         tasks.writeFile(filePath, content);
         return filePath;
     }

--- a/tasks/terraform-cli/src/task-agent/azdo-task-agent.ts
+++ b/tasks/terraform-cli/src/task-agent/azdo-task-agent.ts
@@ -49,6 +49,14 @@ export default class TaskAgent implements ITaskAgent {
         tasks.addAttachment(type, name, filePath);
     }
 
+    attachNewPlanFile(workingDirectory: string, type: string, name: string, content: string) {
+        const stage = tasks.getVariable('System.StageName') || "default_stage";
+        const job = tasks.getVariable('System.JobName') || "default_job";
+        const targetDir = tasks.resolve(workingDirectory, stage, job);
+        const filePath = this.writeFile(targetDir, name, content);
+        tasks.addAttachment(type, name, filePath);
+    }
+
     writeFile(workingDirectory: string, fileName: string, content: string): string {
         const filePath = tasks.resolve(workingDirectory, fileName);
         tasks.writeFile(filePath, content);

--- a/tasks/terraform-cli/src/task-agent/azdo-task-agent.ts
+++ b/tasks/terraform-cli/src/task-agent/azdo-task-agent.ts
@@ -4,6 +4,7 @@ import * as tasks from 'azure-pipelines-task-lib/task';
 import fs from 'fs';
 import Q from 'q';
 import { ITaskAgent } from '.';
+import path from 'path';
 
 export default class TaskAgent implements ITaskAgent {
     private readonly api: WebApi;
@@ -59,6 +60,7 @@ export default class TaskAgent implements ITaskAgent {
 
     writeFile(workingDirectory: string, fileName: string, content: string): string {
         const filePath = tasks.resolve(workingDirectory, fileName);
+        fs.mkdirSync(path.dirname(filePath), { recursive: true });
         tasks.writeFile(filePath, content);
         return filePath;
     }

--- a/tasks/terraform-cli/src/task-agent/index.ts
+++ b/tasks/terraform-cli/src/task-agent/index.ts
@@ -1,5 +1,6 @@
 export interface ITaskAgent {
     downloadSecureFile(secureFileId: string): Promise<string>;
+    attachNewPlanFile(workingDirectory: string, type: string, name: string, content: string): void;
     attachNewFile(workingDirectory: string, type: string, name: string, content: string): void;
     writeFile(workingDirectory: string, fileName: string, content: string): string;
 }

--- a/tasks/terraform-cli/src/task-agent/mock-task-agent.ts
+++ b/tasks/terraform-cli/src/task-agent/mock-task-agent.ts
@@ -2,6 +2,12 @@ import path from "path";
 import { ITaskAgent } from ".";
 
 export default class TaskAgentMock implements ITaskAgent {
+    attachNewPlanFile(workingDirectory: string, type: string, name: string, content: string): void {
+        const targetPath = path.join(workingDirectory, "default_stage", "default_job");
+        const filePath = this.writeFile(targetPath, name, content);
+        this.attachedFiles[name] = { type: type, path: filePath };
+        this.attachedTypes[type] = { [name]: filePath};
+    }
     public readonly attachedFiles: { [name: string]: { type: string, path: string } } = {};
     public readonly attachedTypes: { [type: string]: { [ name: string ]: string } } = {}
     public readonly writtenFiles: { [path: string]: string } = {};


### PR DESCRIPTION
This makes sure plan summaries go to their own folder so they can no longer clash with plan outputs, regardless of the name