### PR TITLE
Show loading message for plans

### DIFF
--- a/views/terraform-plan/src/plan-summary-tab/plan-summary-tab.test.tsx
+++ b/views/terraform-plan/src/plan-summary-tab/plan-summary-tab.test.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { render, unmountComponentAtNode } from 'react-dom';
 import { act } from 'react-dom/test-utils';
 import MockAttachmentService from '../services/attachments/mock-attachment-service';
-import TerraformPlanDisplay, { NoPublishedPlanMessage } from './plan-summary-tab';
+import TerraformPlanDisplay, { LoadingMessage, NoPublishedPlanMessage } from './plan-summary-tab';
 
 let container: HTMLDivElement | null;
 let attachments: MockAttachmentService;
@@ -23,7 +23,7 @@ afterEach(() => {
   container = null;
 })
 
-test("no plans have been published", () => {
+test("still loading", () => {
   act(() => {
     render(<TerraformPlanDisplay attachments={attachments} />, container);  
   });
@@ -33,7 +33,7 @@ test("no plans have been published", () => {
   
   if(elements){
     expect(elements.length).toBe(1);
-    expect(elements[0].innerHTML).toBe(NoPublishedPlanMessage);
+    expect(elements[0].innerHTML).toBe(LoadingMessage);
   }
 });
 

--- a/views/terraform-plan/src/plan-summary-tab/plan-summary-tab.tsx
+++ b/views/terraform-plan/src/plan-summary-tab/plan-summary-tab.tsx
@@ -69,11 +69,7 @@ export default class TerraformPlanDisplay extends React.Component<{ attachments:
                             let html = NoPublishedPlanMessage;
 
                             if (!props.plansLoaded) {
-                                return (
-                                    <div className="flex-row">
-                                        <div>{LoadingMessage}</div>
-                                    </div>
-                                )
+                                html = LoadingMessage;
                             }
                             
                             if (props.chosenPlan > -1) {

--- a/views/terraform-plan/src/plan-summary-tab/plan-summary-tab.tsx
+++ b/views/terraform-plan/src/plan-summary-tab/plan-summary-tab.tsx
@@ -15,12 +15,14 @@ interface TerraformPlan {
 }
 
 export const NoPublishedPlanMessage = "No terraform plans have been published for this pipeline run. The terraform cli task must run plan with <code>publishPlanResults: string</code> (where string represents the plan name) to view plans.";
+export const LoadingMessage = "Loading terraform plans...";
 
 export default class TerraformPlanDisplay extends React.Component<{ attachments: IAttachmentService }> {
 
     private readonly attachments: IAttachmentService
     private readonly terraformPlanAttachmentType: string = "terraform-plan-results"
 
+    private plansLoaded = new ObservableValue(false);
     private planSelection = new DropdownSelection();
     private chosenPlan = new ObservableValue(-1);
     private plans = new ObservableArray<TerraformPlan>([]);
@@ -44,6 +46,7 @@ export default class TerraformPlanDisplay extends React.Component<{ attachments:
         const initialSelection = foundPlans.length - 1
         this.planSelection.select(initialSelection)
         this.chosenPlan.value = initialSelection
+        this.plansLoaded.value = true;
     }
 
     public render(): JSX.Element {
@@ -54,8 +57,8 @@ export default class TerraformPlanDisplay extends React.Component<{ attachments:
                 <Card className="flex-grow flex-column"
                     titleProps={{ text: "Terraform plan output" }}>
 
-                    <Observer chosenPlan={this.chosenPlan} plans={this.plans} >
-                        {(props: { chosenPlan: number, plans: TerraformPlan[] }) => {
+                    <Observer chosenPlan={this.chosenPlan} plans={this.plans} plansLoaded={this.plansLoaded}>
+                        {(props: { chosenPlan: number, plans: TerraformPlan[], plansLoaded: boolean }) => {
                             const planItems = props.plans.map((e: TerraformPlan, index: number) => {
                                 return {
                                     id: index.toString(),
@@ -64,6 +67,15 @@ export default class TerraformPlanDisplay extends React.Component<{ attachments:
                             });
 
                             let html = NoPublishedPlanMessage;
+
+                            if (!props.plansLoaded) {
+                                return (
+                                    <div className="flex-row">
+                                        <div>{LoadingMessage}</div>
+                                    </div>
+                                )
+                            }
+                            
                             if (props.chosenPlan > -1) {
                                 const ansi_up = new AnsiUp()
                                 const planText = props.plans[props.chosenPlan].plan;


### PR DESCRIPTION
This changes the plan view to show a loading message on start up instead of showing no plans.  This should make it more obvious for users that the plans are still loading and if a crash happens.